### PR TITLE
Match other language versions by moving `/api` to the initialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install UnleashClient
 
 ```
 from UnleashClient import UnleashClient
-client = UnleashClient("https://unleash.herokuapp.com", "My Program")
+client = UnleashClient("https://unleash.herokuapp.com/api", "My Program")
 client.initialize_client()
 ```
 
@@ -43,7 +43,7 @@ Argument | Description | Required? |  Type |  Default Value|
 ---------|-------------|-----------|-------|---------------|
 url      | Unleash server URL | Y | String | N/A |
 app_name | Name of your program | Y | String | N/A |
-instance_id | Unique ID for your program | N | String | unleash-client-python | 
+instance_id | Unique ID for your program | N | String | unleash-client-python |
 refresh_interval | How often the unleash client should check for configuration changes. | N | Integer |  15 |
 metrics_interval | How often the unleash client should send metrics to server. | N | Integer | 60 |
 disable_metrics | Disables sending metrics to Unleash server. | N | Boolean | F |

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -7,6 +7,6 @@ REQUEST_TIMEOUT = 30
 APPLICATION_HEADERS = {"Content-Type": "application/json"}
 
 # Paths
-REGISTER_URL = "/api/client/register"
-FEATURES_URL = "/api/client/features"
-METRICS_URL = "/api/client/metrics"
+REGISTER_URL = "/client/register"
+FEATURES_URL = "/client/features"
+METRICS_URL = "/client/metrics"

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ pip install UnleashClient
 
 ```
 from UnleashClient import UnleashClient
-client = UnleashClient("https://unleash.herokuapp.com", "My Program")
+client = UnleashClient("https://unleash.herokuapp.com/api", "My Program")
 client.initialize_client()
 ```
 

--- a/tests/utilities/testing_constants.py
+++ b/tests/utilities/testing_constants.py
@@ -10,8 +10,8 @@ DISABLE_METRICS = True
 CUSTOM_HEADERS = {"name": "My random header."}
 
 # URLs
-URL = "http://localhost:4242"
-INTEGRATION_URL = "http://localhost:4242"
+URL = "http://localhost:4242/api"
+INTEGRATION_URL = "http://localhost:4242/api"
 
 # Constants
 IP_LIST = "69.208.0.0/29,70.208.1.1,2001:db8:1234::/48,2002:db8:1234:0000:0000:0000:0000:0001"


### PR DESCRIPTION
# Description

Match other language versions by moving `/api` to the initialization.
The Go/Ruby/Node/Java versions all set the `/api` part in the initialization as part of the `url` parameter.

Fixes #4 

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [X] Integration tests / Manual Tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas (N/A)
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules