### PR TITLE
Allow configuration of the cache directory

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -25,7 +25,8 @@ class UnleashClient():
                  metrics_interval: int = 60,
                  disable_metrics: bool = False,
                  custom_headers: dict = {},
-                 custom_strategies: dict = {}) -> None:
+                 custom_strategies: dict = {},
+                 cache_directory: str = None) -> None:
         """
         A client for the Unleash feature toggle system.
 
@@ -37,6 +38,7 @@ class UnleashClient():
         :param disable_metrics: Disables sending metrics to unleash server, optional & defaults to false.
         :param custom_headers: Default headers to send to unleash server, optional & defaults to empty.
         :param custom_strategies: Dictionary of custom strategy names : custom strategy objects
+        :param cache_directory: Location of the cache directory. When unset, FCache will determine the location
         """
         # Configuration
         self.unleash_url = url.rstrip('\\')
@@ -48,7 +50,7 @@ class UnleashClient():
         self.unleash_custom_headers = custom_headers
 
         # Class objects
-        self.cache = FileCache(self.unleash_instance_id)
+        self.cache = FileCache(self.unleash_instance_id, app_cache_dir=cache_directory)
         self.features = {}  # type: Dict
         self.scheduler = BackgroundScheduler()
         self.fl_job = None  # type: Job


### PR DESCRIPTION
# Description

Allow manual configuration of the cache directory. In cases where the Python application is run as a user without a home directory, fcache will fail. By default it will choose `~/.cache`, which will not exist.
This PR adds the ability to set the cache directory when initializing the Unleash client.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules