### PR TITLE
Fixes issue where datetimes are sent w/out timezone.

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 from fcache.cache import FileCache
 from apscheduler.job import Job
@@ -55,7 +55,7 @@ class UnleashClient():
         self.scheduler = BackgroundScheduler()
         self.fl_job = None  # type: Job
         self.metric_job = None  # type: Job
-        self.cache[METRIC_LAST_SENT_TIME] = datetime.now()
+        self.cache[METRIC_LAST_SENT_TIME] = datetime.now(timezone.utc)
         self.cache.sync()
 
         # Mappings

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -1,5 +1,5 @@
 import json
-import datetime
+from datetime import datetime, timezone
 import requests
 from UnleashClient.constants import SDK_NAME, SDK_VERSION, REQUEST_TIMEOUT, APPLICATION_HEADERS, REGISTER_URL
 from UnleashClient.utils import LOGGER
@@ -32,7 +32,7 @@ def register_client(url: str,
         "instanceId": instance_id,
         "sdkVersion": "{}:{}".format(SDK_NAME, SDK_VERSION),
         "strategies": [*supported_strategies],
-        "started": datetime.datetime.now().isoformat(),
+        "started": datetime.now(timezone.utc).isoformat(),
         "interval": metrics_interval
     }
 

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -1,5 +1,5 @@
 from collections import ChainMap
-from datetime import datetime
+from datetime import datetime, timezone
 import fcache
 from UnleashClient.api import send_metrics
 from UnleashClient.constants import METRIC_LAST_SENT_TIME
@@ -30,11 +30,11 @@ def aggregate_and_send_metrics(url: str,
         "instanceId": instance_id,
         "bucket": {
             "start": ondisk_cache[METRIC_LAST_SENT_TIME].isoformat(),
-            "stop": datetime.now().isoformat(),
+            "stop": datetime.now(timezone.utc).isoformat(),
             "toggles": dict(ChainMap(*feature_stats_list))
         }
     }
 
     send_metrics(url, metrics_request, custom_headers)
-    ondisk_cache[METRIC_LAST_SENT_TIME] = datetime.now()
+    ondisk_cache[METRIC_LAST_SENT_TIME] = datetime.now(timezone.utc)
     ondisk_cache.sync()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+## v2.1.1
+
+**Bugfixes**
+* (Major) Date/time sent to Unleash (in register, metrics, etc) is correctly in UTC w/timestamp format.
+
 ## v2.1.0
 
 **General**

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -1,5 +1,5 @@
 import json
-import datetime
+from datetime import datetime, timezone, timedelta
 import responses
 from fcache.cache import FileCache
 from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, IP_LIST
@@ -17,7 +17,7 @@ print(FULL_METRICS_URL)
 def test_aggregate_and_send_metrics():
     responses.add(responses.POST, FULL_METRICS_URL, json={}, status=200)
 
-    start_time = datetime.datetime.now() - datetime.timedelta(seconds=60)
+    start_time = datetime.now(timezone.utc) - timedelta(seconds=60)
     cache = FileCache("TestCache")
     cache[METRIC_LAST_SENT_TIME] = start_time
     strategies = [RemoteAddress(parameters={"IPs": IP_LIST}), Default()]


### PR DESCRIPTION
# Description

```
We have been running the new code in production for a week now, and the problem with the false bucket start time is gone. Unfortunately we have ran into another problem. The timestamps generated by datetime.now() is in local time without timezone information, and when sent to the Unleash server it will assume they are in UTC (at least our instance of the server will).
```

Fixed w/minor modification of Calle's code. :)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules