### PR TITLE
Add ability to forward request kwargs

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -28,6 +28,7 @@ class UnleashClient():
                  disable_metrics: bool = False,
                  disable_registration: bool = False,
                  custom_headers: dict = {},
+                 custom_options: dict = {},
                  custom_strategies: dict = {},
                  cache_directory: str = None) -> None:
         """
@@ -41,6 +42,7 @@ class UnleashClient():
         :param metrics_interval: Metrics refresh interval in ms, optional & defaults to 60 seconds
         :param disable_metrics: Disables sending metrics to unleash server, optional & defaults to false.
         :param custom_headers: Default headers to send to unleash server, optional & defaults to empty.
+        :param custom_options: Default requests parameters, optional & defaults to empty.
         :param custom_strategies: Dictionary of custom strategy names : custom strategy objects
         :param cache_directory: Location of the cache directory. When unset, FCache will determine the location
         """
@@ -54,6 +56,7 @@ class UnleashClient():
         self.unleash_disable_metrics = disable_metrics
         self.unleash_disable_registration = disable_registration
         self.unleash_custom_headers = custom_headers
+        self.unleash_custom_options = custom_options
         self.unleash_static_context = {
             "appName": self.unleash_app_name,
             "environment": self.unleash_environment
@@ -101,6 +104,7 @@ class UnleashClient():
             "app_name": self.unleash_app_name,
             "instance_id": self.unleash_instance_id,
             "custom_headers": self.unleash_custom_headers,
+            "custom_options": self.unleash_custom_options,
             "cache": self.cache,
             "features": self.features,
             "strategy_mapping": self.strategy_mapping
@@ -111,6 +115,7 @@ class UnleashClient():
             "app_name": self.unleash_app_name,
             "instance_id": self.unleash_instance_id,
             "custom_headers": self.unleash_custom_headers,
+            "custom_options": self.unleash_custom_options,
             "features": self.features,
             "ondisk_cache": self.cache
         }
@@ -118,7 +123,8 @@ class UnleashClient():
         # Register app
         if not self.unleash_disable_registration:
             register_client(self.unleash_url, self.unleash_app_name, self.unleash_instance_id,
-                            self.unleash_metrics_interval, self.unleash_custom_headers, self.strategy_mapping)
+                            self.unleash_metrics_interval, self.unleash_custom_headers,
+                            self.unleash_custom_options, self.strategy_mapping)
 
         fetch_and_load_features(**fl_args)
 

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -7,7 +7,8 @@ from UnleashClient.utils import LOGGER
 def get_feature_toggles(url: str,
                         app_name: str,
                         instance_id: str,
-                        custom_headers: dict) -> dict:
+                        custom_headers: dict,
+                        custom_options: dict) -> dict:
     """
     Retrieves feature flags from unleash central server.
 
@@ -19,6 +20,7 @@ def get_feature_toggles(url: str,
     :param app_name:
     :param instance_id:
     :param custom_headers:
+    :param custom_options:
     :return: Feature flags if successful, empty dict if not.
     """
     try:
@@ -31,7 +33,7 @@ def get_feature_toggles(url: str,
 
         resp = requests.get(url + FEATURES_URL,
                             headers={**custom_headers, **headers},
-                            timeout=REQUEST_TIMEOUT)
+                            timeout=REQUEST_TIMEOUT, **custom_options)
 
         if resp.status_code != 200:
             LOGGER.warning("unleash feature fetch failed!")

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -7,7 +7,8 @@ from UnleashClient.utils import LOGGER
 # pylint: disable=broad-except
 def send_metrics(url: str,
                  request_body: dict,
-                 custom_headers: dict) -> bool:
+                 custom_headers: dict,
+                 custom_options: dict) -> bool:
     """
     Attempts to send metrics to Unleash server
 
@@ -19,6 +20,7 @@ def send_metrics(url: str,
     :param instance_id:
     :param metrics_interval:
     :param custom_headers:
+    :param custom_options:
     :return: true if registration successful, false if registration unsuccessful or exception.
     """
     try:
@@ -28,7 +30,7 @@ def send_metrics(url: str,
         resp = requests.post(url + METRICS_URL,
                              data=json.dumps(request_body),
                              headers={**custom_headers, **APPLICATION_HEADERS},
-                             timeout=REQUEST_TIMEOUT)
+                             timeout=REQUEST_TIMEOUT, **custom_options)
 
         if resp.status_code != 202:
             LOGGER.warning("unleash metrics submission failed.")

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -11,6 +11,7 @@ def register_client(url: str,
                     instance_id: str,
                     metrics_interval: int,
                     custom_headers: dict,
+                    custom_options: dict,
                     supported_strategies: dict) -> bool:
     """
     Attempts to register client with unleash server.
@@ -24,6 +25,7 @@ def register_client(url: str,
     :param instance_id:
     :param metrics_interval:
     :param custom_headers:
+    :param custom_options:
     :param supported_strategies:
     :return: true if registration successful, false if registration unsuccessful or exception.
     """
@@ -43,7 +45,7 @@ def register_client(url: str,
         resp = requests.post(url + REGISTER_URL,
                              data=json.dumps(registation_request),
                              headers={**custom_headers, **APPLICATION_HEADERS},
-                             timeout=REQUEST_TIMEOUT)
+                             timeout=REQUEST_TIMEOUT, **custom_options)
 
         if resp.status_code != 202:
             LOGGER.warning("unleash client registration failed.")

--- a/UnleashClient/periodic_tasks/fetch_and_load.py
+++ b/UnleashClient/periodic_tasks/fetch_and_load.py
@@ -9,10 +9,11 @@ def fetch_and_load_features(url: str,
                             app_name: str,
                             instance_id: str,
                             custom_headers: dict,
+                            custom_options: dict,
                             cache: FileCache,
                             features: dict,
                             strategy_mapping: dict) -> None:
-    feature_provisioning = get_feature_toggles(url, app_name, instance_id, custom_headers)
+    feature_provisioning = get_feature_toggles(url, app_name, instance_id, custom_headers, custom_options)
 
     if feature_provisioning:
         cache[FEATURES_URL] = feature_provisioning

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -9,6 +9,7 @@ def aggregate_and_send_metrics(url: str,
                                app_name: str,
                                instance_id: str,
                                custom_headers: dict,
+                               custom_options: dict,
                                features: dict,
                                ondisk_cache: fcache.cache
                                ) -> None:
@@ -35,6 +36,6 @@ def aggregate_and_send_metrics(url: str,
         }
     }
 
-    send_metrics(url, metrics_request, custom_headers)
+    send_metrics(url, metrics_request, custom_headers, custom_options)
     ondisk_cache[METRIC_LAST_SENT_TIME] = datetime.now(timezone.utc)
     ondisk_cache.sync()

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -1,53 +1,30 @@
 import responses
+from pytest import mark, param
 from requests import ConnectionError
 from UnleashClient.constants import REGISTER_URL
 from UnleashClient.api import register_client
-from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, METRICS_INTERVAL, CUSTOM_HEADERS, DEFAULT_STRATEGY_MAPPING
+from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, METRICS_INTERVAL, CUSTOM_HEADERS, CUSTOM_OPTIONS, DEFAULT_STRATEGY_MAPPING
 
 
 FULL_REGISTER_URL = URL + REGISTER_URL
 
 
 @responses.activate
-def test_register_client_success():
-    responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=202)
+@mark.parametrize("payload,status,expected", (
+    param({"json": {}}, 202, True, id="success"),
+    param({"json": {}}, 500, False, id="failure"),
+    param({"body": ConnectionError("Test connection error")}, 200, False, id="exception"),
+))
+def test_register_client(payload, status, expected):
+    responses.add(responses.POST, FULL_REGISTER_URL, **payload, status=status)
 
     result = register_client(URL,
                              APP_NAME,
                              INSTANCE_ID,
                              METRICS_INTERVAL,
                              CUSTOM_HEADERS,
+                             CUSTOM_OPTIONS,
                              DEFAULT_STRATEGY_MAPPING)
 
     assert len(responses.calls) == 1
-    assert result
-
-
-@responses.activate
-def test_register_client_failure():
-    responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=500)
-
-    result = register_client(URL,
-                             APP_NAME,
-                             INSTANCE_ID,
-                             METRICS_INTERVAL,
-                             CUSTOM_HEADERS,
-                             DEFAULT_STRATEGY_MAPPING)
-
-    assert len(responses.calls) == 1
-    assert not result
-
-
-@responses.activate
-def test_register_client_exception():
-    responses.add(responses.POST, FULL_REGISTER_URL, body=ConnectionError("Test connection error."), status=200)
-
-    result = register_client(URL,
-                             APP_NAME,
-                             INSTANCE_ID,
-                             METRICS_INTERVAL,
-                             CUSTOM_HEADERS,
-                             DEFAULT_STRATEGY_MAPPING)
-
-    assert len(responses.calls) == 1
-    assert not result
+    assert result is expected

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timezone, timedelta
 import responses
 from fcache.cache import FileCache
-from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, IP_LIST
+from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, IP_LIST
 from UnleashClient.constants import METRICS_URL, METRIC_LAST_SENT_TIME
 from UnleashClient.periodic_tasks import aggregate_and_send_metrics
 from UnleashClient.features import Feature
@@ -31,7 +31,7 @@ def test_aggregate_and_send_metrics():
 
     features = {"My Feature1": my_feature1, "My Feature 2": my_feature2}
 
-    aggregate_and_send_metrics(URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, features, cache)
+    aggregate_and_send_metrics(URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache)
 
     assert len(responses.calls) == 1
     request = json.loads(responses.calls[0].request.body)

--- a/tests/unit_tests/periodic/test_fetch_and_load.py
+++ b/tests/unit_tests/periodic/test_fetch_and_load.py
@@ -3,7 +3,7 @@ from UnleashClient.constants import FEATURES_URL
 from UnleashClient.periodic_tasks import fetch_and_load_features
 from UnleashClient.features import Feature
 from tests.utilities.mocks.mock_features import MOCK_FEATURE_RESPONSE
-from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, DEFAULT_STRATEGY_MAPPING
+from tests.utilities.testing_constants import URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, DEFAULT_STRATEGY_MAPPING
 from tests.utilities.decorators import cache_empty  # noqa: F401
 
 
@@ -21,6 +21,7 @@ def test_fetch_and_load(cache_empty):  # noqa: F811
                             APP_NAME,
                             INSTANCE_ID,
                             CUSTOM_HEADERS,
+                            CUSTOM_OPTIONS,
                             temp_cache,
                             in_memory_features,
                             DEFAULT_STRATEGY_MAPPING)
@@ -39,6 +40,7 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
                             APP_NAME,
                             INSTANCE_ID,
                             CUSTOM_HEADERS,
+                            CUSTOM_OPTIONS,
                             temp_cache,
                             in_memory_features,
                             DEFAULT_STRATEGY_MAPPING)
@@ -51,6 +53,7 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
                             APP_NAME,
                             INSTANCE_ID,
                             CUSTOM_HEADERS,
+                            CUSTOM_OPTIONS,
                             temp_cache,
                             in_memory_features,
                             DEFAULT_STRATEGY_MAPPING)

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -5,7 +5,7 @@ import responses
 from UnleashClient import UnleashClient
 from UnleashClient.strategies import Strategy
 from tests.utilities.testing_constants import URL, ENVIRONMENT, APP_NAME, INSTANCE_ID, REFRESH_INTERVAL, \
-    METRICS_INTERVAL, DISABLE_METRICS, DISABLE_REGISTRATION, CUSTOM_HEADERS
+    METRICS_INTERVAL, DISABLE_METRICS, DISABLE_REGISTRATION, CUSTOM_HEADERS, CUSTOM_OPTIONS
 from tests.utilities.mocks.mock_features import MOCK_FEATURE_RESPONSE
 from tests.utilities.mocks.mock_all_features import MOCK_ALL_FEATURES
 from UnleashClient.constants import REGISTER_URL, FEATURES_URL, METRICS_URL
@@ -85,13 +85,15 @@ def test_UC_initialize_full():
                            METRICS_INTERVAL,
                            DISABLE_METRICS,
                            DISABLE_REGISTRATION,
-                           CUSTOM_HEADERS)
+                           CUSTOM_HEADERS,
+                           CUSTOM_OPTIONS)
     assert client.unleash_instance_id == INSTANCE_ID
     assert client.unleash_refresh_interval == REFRESH_INTERVAL
     assert client.unleash_metrics_interval == METRICS_INTERVAL
     assert client.unleash_disable_metrics == DISABLE_METRICS
     assert client.unleash_disable_registration == DISABLE_REGISTRATION
     assert client.unleash_custom_headers == CUSTOM_HEADERS
+    assert client.unleash_custom_options == CUSTOM_OPTIONS
 
 
 def test_UC_type_violation():

--- a/tests/utilities/testing_constants.py
+++ b/tests/utilities/testing_constants.py
@@ -10,6 +10,7 @@ METRICS_INTERVAL = 10
 DISABLE_METRICS = True
 DISABLE_REGISTRATION = True
 CUSTOM_HEADERS = {"name": "My random header."}
+CUSTOM_OPTIONS = {"verify": False}
 
 # URLs
 URL = "http://localhost:4242/api"


### PR DESCRIPTION
# Description

* For on-premises Unleash servers, having the ability to bypass or override SSL certificate verification is convenient. This update allows us to forward custom kwargs to `request.post` during client registration to allow for these kinds of customizations

* Also, refactored relevant unit tests to reduce code duplication

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules