### PR TITLE
Rc 4.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.6.0
 commit = True
 tag = True
 message = Automatic version bump via bumpversion.

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -1,6 +1,6 @@
 # Library
 SDK_NAME = "unleash-client-python"
-SDK_VERSION = "2.5.0"
+SDK_VERSION = "2.6.0"
 REQUEST_TIMEOUT = 30
 METRIC_LAST_SENT_TIME = "mlst"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,12 @@
+## v2.6.0
+
+General
+* (Minor) Add ability to add request kwargs when initializing the client.  These will be used when registering the client, fetching feature flags, and sending metrics. 
+
 ## v2.5.0
 
 **General**
-* (Minor) Unleash client will not error if cache is not present and Unleash server not accessible during initialization..
+* (Minor) Unleash client will not error if cache is not present and Unleash server not accessible during initialization.
 
 ## v2.4.0
 

--- a/docs/unleashclient.md
+++ b/docs/unleashclient.md
@@ -19,6 +19,7 @@ metrics_interval | How often the unleash client should send metrics to server. |
 disable_metrics | Disables sending metrics to Unleash server. | N | Boolean | F |
 disable_registration | Disables registration with Unleash server. | N | Boolean | F |
 custom_headers | Custom headers to send to Unleash. | N | Dictionary | {}
+custom_options | Custom arguments for requests package. | N | Dictionary | {}
 custom_strategies | Custom strategies you'd like UnleashClient to support. | N | Dictionary | {} |
 cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset | 
 
@@ -69,5 +70,20 @@ my_client = UnleashClient(
     instance_id="myinstanceid",
     disable_metrics=True,
     disable_registration=True
+)
+```
+
+**Overriding SSL certificate verification**
+
+(Do this at your own risk!)
+
+If using an on-prem SSL certificate with a self-signed cert, you can pass custom arguments through to the **request** package using the *custom_options* argument.
+
+```python
+my_client = UnleashClient(
+    url="https://myunleash.hamster.com",
+    app_name="myClient1",
+    instance_id="myinstanceid",
+    custom_options={"verify": False}
 )
 ```

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='UnleashClient',
-    version='2.5.0',
+    version='2.6.0',
     author='Ivan Lee',
     author_email='ivanklee86@gmail.com',
     description='Python client for the Unleash feature toggle system!',


### PR DESCRIPTION
Changes:

General
* (Minor) Add ability to add request kwargs when initializing the client.  These will be used when registering the client, fetching feature flags, and sending metrics. 