### PR TITLE
Add deprecation warning if folks try to use old Custom Strategies

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -84,8 +84,10 @@ class UnleashClient():
             "flexibleRollout": FlexibleRollout
         }
 
+        if custom_strategies:
+            strategy_v2xx_deprecation_check([x for x in custom_strategies.values()])  # pylint: disable=R1721
+
         self.strategy_mapping = {**custom_strategies, **default_strategy_mapping}
-        strategy_v2xx_deprecation_check([x for x in custom_strategies.values()])  #pylint: disable=R1721
 
         # Client status
         self.is_initialized = False

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -10,6 +10,7 @@ from UnleashClient.strategies import ApplicationHostname, Default, GradualRollou
     GradualRolloutSessionId, GradualRolloutUserId, UserWithId, RemoteAddress, FlexibleRollout
 from UnleashClient.constants import METRIC_LAST_SENT_TIME
 from .utils import LOGGER
+from .deprecation_warnings import strategy_v2xx_deprecation_check
 
 
 # pylint: disable=dangerous-default-value
@@ -84,6 +85,7 @@ class UnleashClient():
         }
 
         self.strategy_mapping = {**custom_strategies, **default_strategy_mapping}
+        strategy_v2xx_deprecation_check([x for x in custom_strategies.values()])  #pylint: disable=R1721
 
         # Client status
         self.is_initialized = False

--- a/UnleashClient/deprecation_warnings.py
+++ b/UnleashClient/deprecation_warnings.py
@@ -1,0 +1,19 @@
+import warnings
+from UnleashClient.strategies import Strategy
+
+
+def strategy_v2xx_deprecation_check(strategies: list) -> None:
+    """
+    Notify users of backwards incompatible changes in v3 for custom strategies.
+    """
+    for strategy in strategies:
+        try:
+            # Check if the __call__() method is overwritten (should only be true for custom strategies in v1.x or v2.x.
+            if strategy.__call__ != Strategy.__call__:
+                warnings.warn(
+                    "unleash-client-python v3.x.x requires overriding the execute() method instead of the __call__() method. Error in: {}".format(strategy.__name__),
+                    DeprecationWarning
+                )
+        except AttributeError:
+            # Ignore if not.
+            pass

--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -1,6 +1,4 @@
-import warnings
 from UnleashClient.utils import LOGGER
-from UnleashClient.strategies import Strategy
 
 
 # pylint: disable=dangerous-default-value, broad-except
@@ -56,8 +54,6 @@ class Feature:
         :param default_value: Optional, but allows for override.
         :return:
         """
-        self.__deprecation_check()
-
         flag_value = default_value
 
         if self.enabled:
@@ -72,19 +68,3 @@ class Feature:
         LOGGER.info("Feature toggle status for feature %s: %s", self.name, flag_value)
 
         return flag_value
-
-    def __deprecation_check(self):
-        """
-        Notify users of backwards incompatible changes in v3 for custom strategies.
-        """
-        for strategy in self.strategies:
-            try:
-                # Check if the __call__() method is overwritten (should only be true for custom strategies in v1.x or v2.x.
-                if strategy.__call__ != Strategy.__call__:
-                    warnings.warn(
-                        "unleash-client-python v3.x.x requires overriding the execute() method instead of the __call__() method. Error in: {}".format(type(strategy)),
-                        DeprecationWarning
-                    )
-            except AttributeError:
-                # Ignore if not.
-                pass

--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -1,4 +1,6 @@
+import warnings
 from UnleashClient.utils import LOGGER
+from UnleashClient.strategies import Strategy
 
 
 # pylint: disable=dangerous-default-value, broad-except
@@ -54,6 +56,8 @@ class Feature:
         :param default_value: Optional, but allows for override.
         :return:
         """
+        self.__deprecation_check()
+
         flag_value = default_value
 
         if self.enabled:
@@ -68,3 +72,19 @@ class Feature:
         LOGGER.info("Feature toggle status for feature %s: %s", self.name, flag_value)
 
         return flag_value
+
+    def __deprecation_check(self):
+        """
+        Notify users of backwards incompatible changes in v3 for custom strategies.
+        """
+        for strategy in self.strategies:
+            try:
+                # Check if the __call__() method is overwritten (should only be true for custom strategies in v1.x or v2.x.
+                if strategy.__call__ != Strategy.__call__:
+                    warnings.warn(
+                        "unleash-client-python v3.x.x requires overriding the execute() method instead of the __call__() method. Error in: {}".format(type(strategy)),
+                        DeprecationWarning
+                    )
+            except AttributeError:
+                # Ignore if not.
+                pass

--- a/UnleashClient/strategies/Strategies.py
+++ b/UnleashClient/strategies/Strategies.py
@@ -1,4 +1,5 @@
 # pylint: disable=dangerous-default-value
+import warnings
 from UnleashClient.constraints import Constraint
 
 
@@ -27,8 +28,11 @@ class Strategy:
         self.parsed_constraints = self.load_constraints(constraints)
         self.parsed_provisioning = self.load_provisioning()
 
-    def __call__(self, context: dict = None) -> bool:
-        raise DeprecationWarning("unleash-client-python no longer uses the __call__() method.  Please use execute_strategy() instead.")
+    def __call__(self, context: dict = None):
+        warnings.warn(
+            "unleash-client-python v3.x.x requires overriding the execute() method instead of the __call__() method.",
+            DeprecationWarning
+        )
 
     def execute(self, context: dict = None) -> bool:
         """

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -3,7 +3,6 @@ import mmh3  # pylint: disable=import-error
 
 LOGGER = logging.getLogger(__name__)
 
-
 def normalized_hash(identifier: str,
                     activation_group: str) -> int:
     return mmh3.hash("{}:{}".format(activation_group, identifier), signed=False) % 100 + 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts=--flake8 --disable-warnings --log-level INFO
+addopts=--flake8 --log-level INFO

--- a/tests/unit_tests/test_custom_strategy.py
+++ b/tests/unit_tests/test_custom_strategy.py
@@ -24,21 +24,92 @@ class CatTest(Strategy):
         return default_value
 
 
+class DogTest(Strategy):
+    def load_provisioning(self) -> list:
+        return [x.strip() for x in self.parameters["sound"].split(',')]
+
+    def _call_(self, context: dict = None) -> bool:
+        """
+        Turn on if I'm a dog.
+
+        :return:
+        """
+        default_value = False
+
+        if "sound" in context.keys():
+            default_value = context["sound"] in self.parsed_provisioning
+
+        return default_value
+
+
 @responses.activate
-def test_uc_custom_strategy():
-    # Set up API
+def test_uc_customstrategy_happypath():
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
     responses.add(responses.GET, URL + FEATURES_URL, json=MOCK_CUSTOM_STRATEGY, status=200)
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
     custom_strategies_dict = {
-        "amIACat": CatTest
+        "amIACat": CatTest,
+        "amIADog": DogTest
     }
 
-    unleash_client = UnleashClient(URL, APP_NAME, custom_strategies=custom_strategies_dict)
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        environment="prod",
+        custom_strategies=custom_strategies_dict)
 
-    # Create Unleash client and check initial load
     unleash_client.initialize_client()
 
     assert unleash_client.is_enabled("CustomToggle", {"sound": "meow"})
     assert not unleash_client.is_enabled("CustomToggle", {"sound": "bark"})
+
+
+@responses.activate
+def test_uc_customstrategy_depredationwarning(recwarn):
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(responses.GET, URL + FEATURES_URL, json=MOCK_CUSTOM_STRATEGY, status=200)
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    custom_strategies_dict = {
+        "amIACat": CatTest,
+        "amIADog": DogTest
+    }
+
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        environment="prod",
+        custom_strategies=custom_strategies_dict)
+
+    unleash_client.initialize_client()
+
+    # Generate a deprecation warning.
+
+    assert not unleash_client.is_enabled("CustomToggleWarning", {"sound": "meow"})
+    assert len(recwarn) == 1
+    assert recwarn.pop(DeprecationWarning)
+
+
+@responses.activate
+def test_uc_customstrategy_safemulti():
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(responses.GET, URL + FEATURES_URL, json=MOCK_CUSTOM_STRATEGY, status=200)
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    custom_strategies_dict = {
+        "amIACat": CatTest,
+        "amIADog": DogTest
+    }
+
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        environment="prod",
+        custom_strategies=custom_strategies_dict)
+
+    unleash_client.initialize_client()
+
+    # Generate a deprecation warning.
+
+    assert unleash_client.is_enabled("CustomToggleWarningMultiStrat", {"sound": "meow"})

--- a/tests/utilities/mocks/mock_custom_strategy.py
+++ b/tests/utilities/mocks/mock_custom_strategy.py
@@ -10,20 +10,6 @@ MOCK_CUSTOM_STRATEGY = {
           "name": "amIACat",
           "parameters": {
             "sound": "meow,nyaa"
-          }
-        }
-      ],
-      "createdAt": "2018-10-13T10:15:29.009Z"
-    },
-    {
-      "name": "CustomToggleV2",
-      "description": "CustomToggle v2 Test",
-      "enabled": True,
-      "strategies": [
-        {
-          "name": "amIADog",
-          "parameters": {
-            "sound": "arf,bark"
           },
           "constraints": [
             {
@@ -35,6 +21,38 @@ MOCK_CUSTOM_STRATEGY = {
               ]
             }
           ]
+        }
+      ],
+      "createdAt": "2018-10-13T10:15:29.009Z"
+    },
+    {
+      "name": "CustomToggleWarning",
+      "description": "CustomToggle Warning Test",
+      "enabled": True,
+      "strategies": [
+        {
+          "name": "amIADog",
+          "parameters": {
+            "sound": "arf,bark"
+          }
+        }
+      ],
+      "createdAt": "2018-10-13T10:15:29.009Z"
+    },
+    {
+      "name": "CustomToggleWarningMultiStrat",
+      "description": "CustomToggle Warning Test",
+      "enabled": True,
+      "strategies": [
+        {
+          "name": "amIADog",
+          "parameters": {
+            "sound": "arf,bark"
+          }
+        },
+        {
+          "name": "default",
+          "parameters": {}
         }
       ],
       "createdAt": "2018-10-13T10:15:29.009Z"

--- a/tests/utilities/old_code/StrategyV2.py
+++ b/tests/utilities/old_code/StrategyV2.py
@@ -1,0 +1,39 @@
+#Old Strategy object from unleash-client-python version 1.x.x and 2.x.x
+
+# pylint: disable=dangerous-default-value
+class StrategyOldV2():
+    """
+    In general, default & custom classes should only need to override:
+    * __call__() - Implementation of the strategy.
+    * load_provisioning - Loads strategy provisioning
+    """
+    def __init__(self,
+                 parameters: dict = {}) -> None:
+        """
+        A generic strategy objects.
+        :param parameters: 'parameters' key from strategy section (...from feature section) of
+        /api/clients/features response
+        """
+        # Experiment information
+        self.parameters = parameters
+
+        self.parsed_provisioning = self.load_provisioning()
+
+    # pylint: disable=no-self-use
+    def load_provisioning(self) -> list:
+        """
+        Method to load data on object initialization, if desired.
+        This should parse the raw values in self.parameters into format Python can comprehend.
+        """
+        return []
+
+    def __eq__(self, other):
+        return self.parameters == other.parameters
+
+    def __call__(self, context: dict = None) -> bool:
+        """
+        Strategy implementation goes here.
+        :param context: Context information
+        :return:
+        """
+        return False


### PR DESCRIPTION
# Description
- On client initialization, compare the `__call__` method on custom strategies to the `__call__` method on the base Strategy object (which is basically just a warning) for all custom strategies.  If they are different (i.e. an old custom strategy), show a DeprecationWarning.
- Add unit tests to ensure a) we're throwing the warning and b) features with old invalid custom strategies return appropriate values.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules