### PR TITLE
rc-4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.2
+current_version = 4.0.0
 commit = True
 tag = True
 message = Automatic version bump via bumpversion.

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -1,6 +1,6 @@
 # Library
 SDK_NAME = "unleash-client-python"
-SDK_VERSION = "3.4.2"
+SDK_VERSION = "4.0.0"
 REQUEST_TIMEOUT = 30
 METRIC_LAST_SENT_TIME = "mlst"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,12 @@
-## Next version
+## Next Version
+
+## v4.0.0
 
 **General**
 * (Major) Stop using the `default_value` argument in the `is_enabled()` method (as it can cause counter-intuitive behavior) and add deprecation warning.  This argument will be removed in the next major version upgrade!  
     * We recommend using the `fallback_function` argument instead.  If you need a blanket True in case of an exception, you can pass in a lambda like: `lambda x, y: True`. 
 * (Minor) Add better logging for API errors.
-
+* (Minor) Bump requests version.
 
 ## v3.4.1, v3.4.2
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='UnleashClient',
-    version='3.4.2',
+    version='4.0.0',
     author='Ivan Lee',
     author_email='ivanklee86@gmail.com',
     description='Python client for the Unleash feature toggle system!',


### PR DESCRIPTION
Release Candidate for 4.0.0.

```
**General**
* (Major) Stop using the `default_value` argument in the `is_enabled()` method (as it can cause counter-intuitive behavior) and add deprecation warning.  This argument will be removed in the next major version upgrade!  
    * We recommend using the `fallback_function` argument instead.  If you need a blanket True in case of an exception, you can pass in a lambda like: `lambda x, y: True`. 
* (Minor) Add better logging for API errors.
* (Minor) Bump requests version.
```