### PR TITLE
Fix Github Actions for PRs from a forked repo

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push
-  pull_request_target
+  push:
+  pull_request_target:
 
 jobs:
   main:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on:
+  push
+  pull_request_target
 
 jobs:
   main:


### PR DESCRIPTION
Add the `pull_request_target` event to the standard CI/CD workflow.