### PR TITLE
Log errors from submitting metrics as warnings and not exceptions.

### DIFF
--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -39,6 +39,6 @@ def send_metrics(url: str,
 
         return True
     except requests.RequestException as exc:
-        LOGGER.exception("Unleash Client metrics submission failed due to exception: %s", exc)
+        LOGGER.warning("Unleash Client metrics submission failed due to exception: %s", exc)
 
     return False

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
 ## Next version
+* (Minor) Errors submitting metrics will be logged as warnings and not exceptions.
+* (Minor) Update apscheduler version to 3.7.0
 
 ## v3.5.1
 * (Minor) Better error handling and typo fixes.  Thanks @vgerak!


### PR DESCRIPTION
# Description

Log errors from submitting metrics (i.e. due to timeouts) as `warnings` and not `exceptions`.  As metrics are a reporting function, this feels like a more appropriate log level. :)

I'm leaving the feature and registration logging alone since those are much more important to UCP.

Fixes #122 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules