### PR TITLE
rc for v3.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.1
+current_version = 3.6.0
 commit = True
 tag = True
 message = Automatic version bump via bumpversion.

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -1,6 +1,6 @@
 # Library
 SDK_NAME = "unleash-client-python"
-SDK_VERSION = "3.5.1"
+SDK_VERSION = "3.6.0"
 REQUEST_TIMEOUT = 30
 METRIC_LAST_SENT_TIME = "mlst"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,8 @@
 ## Next version
+
+## v3.6.0
+* (Minor) Add Python 3.9 support.
+* (Minor) Only log errors generated when strategy loading fails once.
 * (Minor) Errors submitting metrics will be logged as warnings and not exceptions.
 * (Minor) Update apscheduler version to 3.7.0
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='UnleashClient',
-    version='3.5.1',
+    version='3.6.0',
     author='Ivan Lee',
     author_email='ivanklee86@gmail.com',
     description='Python client for the Unleash feature toggle system!',


### PR DESCRIPTION
Changes:
* (Minor) Add Python 3.9 support.
* (Minor) Only log errors generated when strategy loading fails once.
* (Minor) Errors submitting metrics will be logged as warnings and not exceptions.
* (Minor) Update apscheduler version to 3.7.0