### PR TITLE
Fix issue with updating in-memory variants in the loader

### DIFF
--- a/UnleashClient/loader.py
+++ b/UnleashClient/loader.py
@@ -95,7 +95,7 @@ def load_features(cache: FileCache,
                 feature_for_update.strategies = parsed_strategies
 
             if 'variants' in parsed_features[feature]:
-                feature_for_update.variants = Variants(
+                feature_for_update.variations = Variants(
                     parsed_features[feature]['variants'],
                     parsed_features[feature]['name']
                 )

--- a/tests/unit_tests/test_loader.py
+++ b/tests/unit_tests/test_loader.py
@@ -8,9 +8,6 @@ from tests.utilities.mocks import MOCK_ALL_FEATURES
 from tests.utilities.testing_constants import DEFAULT_STRATEGY_MAPPING
 from tests.utilities.decorators import cache_full, cache_custom  # noqa: F401
 
-MOCK_UPDATED = copy.deepcopy(MOCK_ALL_FEATURES)
-MOCK_UPDATED["features"][4]["strategies"][0]["parameters"]["percentage"] = 60
-
 
 def test_loader_initialization(cache_full):  # noqa: F811
     # Set up variables
@@ -41,7 +38,7 @@ def test_loader_initialization(cache_full):  # noqa: F811
             assert strategy.variants
 
 
-def test_loader_refresh(cache_full):  # noqa: F811
+def test_loader_refresh_strategies(cache_full):  # noqa: F811
     # Set up variables
     in_memory_features = {}
     temp_cache = cache_full
@@ -49,13 +46,33 @@ def test_loader_refresh(cache_full):  # noqa: F811
     load_features(temp_cache, in_memory_features, DEFAULT_STRATEGY_MAPPING)
 
     # Simulate update mutation
-    temp_cache[FEATURES_URL] = MOCK_UPDATED
+    mock_updated = copy.deepcopy(MOCK_ALL_FEATURES)
+    mock_updated["features"][4]["strategies"][0]["parameters"]["percentage"] = 60
+    temp_cache[FEATURES_URL] = mock_updated
     temp_cache.sync()
 
     load_features(temp_cache, in_memory_features, DEFAULT_STRATEGY_MAPPING)
 
     assert in_memory_features["GradualRolloutUserID"].strategies[0].parameters["percentage"] == 60
     assert len(temp_cache[FAILED_STRATEGIES]) == 1
+
+
+def test_loader_refresh_variants(cache_full):  # noqa: F811
+    # Set up variables
+    in_memory_features = {}
+    temp_cache = cache_full
+
+    load_features(temp_cache, in_memory_features, DEFAULT_STRATEGY_MAPPING)
+
+    # Simulate update mutation
+    mock_updated = copy.deepcopy(MOCK_ALL_FEATURES)
+    mock_updated["features"][8]["variants"][0]["name"] = "VariantA"
+    temp_cache[FEATURES_URL] = mock_updated
+    temp_cache.sync()
+
+    load_features(temp_cache, in_memory_features, DEFAULT_STRATEGY_MAPPING)
+
+    assert in_memory_features["Variations"].variations.variants[0]["name"] == "VariantA"
 
 
 def test_loader_initialization_failure(cache_custom):  # noqa: F811


### PR DESCRIPTION
# Description

When the new features are downloaded, the loader first updates the file cache before updating
the in-memory cache.

This PR attempts to fix an issue where the loader did not properly update the variants part of the cache.
This caused the variants to be stale until the next cache initialisation on client restart.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules