### PR TITLE
Fix Pylint ‘R1729: Use a generator instead’ warnings

### DIFF
--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -63,7 +63,7 @@ class Feature:
         if self.enabled:
             try:
                 if self.strategies:
-                    strategy_result = any([x.execute(context) for x in self.strategies])
+                    strategy_result = any(x.execute(context) for x in self.strategies)
                 else:
                     # If no strategies are present, should default to true. This isn't possible via UI.
                     strategy_result = True

--- a/UnleashClient/strategies/Strategy.py
+++ b/UnleashClient/strategies/Strategy.py
@@ -45,7 +45,7 @@ class Strategy:
         """
         flag_state = False
 
-        if all([constraint.apply(context) for constraint in self.parsed_constraints]):
+        if all(constraint.apply(context) for constraint in self.parsed_constraints):
             flag_state = self.apply(context)
 
         return flag_state

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,6 @@ envlist = py35,py36,py37,py38,py39
 deps = -rrequirements.txt
 commands =
     mypy UnleashClient
+    pylint UnleashClient
     py.test --cov UnleashClient tests/unit_tests
     py.test --cov UnleashClient tests/specification_tests


### PR DESCRIPTION
# Description

This fixes two instances of Pylint warning about ‘R1729: Use a generator
instead’.

It also adds pylint to tox.ini, to keep it in sync with the tox-osx.ini
file, and with the Github Actions setup.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules