### PR TITLE
rc-v4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.6.2
+current_version = 4.0.0
 commit = True
 tag = True
 message = Automatic version bump via bumpversion.

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -1,6 +1,6 @@
 # Library
 SDK_NAME = "unleash-client-python"
-SDK_VERSION = "3.6.2"
+SDK_VERSION = "4.0.0"
 REQUEST_TIMEOUT = 30
 METRIC_LAST_SENT_TIME = "mlst"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
 ## Next version
+
+## v4.0.0
 * (Major) Deprecate the `default_value` argument in the `is_enabled()` method.
 * (Major) Drop Python 3.5 support.
 * (Minor) Remove dependencies versions constraints.  Thanks @wbolster and @isra17!

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='UnleashClient',
-    version='3.6.2',
+    version='4.0.0',
     author='Ivan Lee',
     author_email='ivanklee86@gmail.com',
     description='Python client for the Unleash feature toggle system!',


### PR DESCRIPTION
RC branch!

Changelog:
* (Major) Deprecate the `default_value` argument in the `is_enabled()` method.
* (Major) Drop Python 3.5 support.
* (Minor) Remove dependencies versions constraints.  Thanks @wbolster and @isra17!
* (Bugfix) Don't use mutable defaults.  Thanks @aviau!
