### PR TITLE
Fix intermittent specification test failures introduced by custom context field changes.

### DIFF
--- a/UnleashClient/strategies/FlexibleRolloutStrategy.py
+++ b/UnleashClient/strategies/FlexibleRolloutStrategy.py
@@ -16,7 +16,7 @@ class FlexibleRollout(Strategy):
         """
         percentage = int(self.parameters['rollout'])
         activation_group = self.parameters['groupId']
-        stickiness = self.parameters['stickiness']
+        stickiness = self.parameters['stickiness'] if "stickiness" in self.parameters else "default"
 
         if stickiness == 'default':
             if 'userId' in context.keys():
@@ -25,10 +25,9 @@ class FlexibleRollout(Strategy):
                 calculated_percentage = normalized_hash(context['sessionId'], activation_group)
             else:
                 calculated_percentage = self.random_hash()
-        elif stickiness in context.keys():
-            calculated_percentage = normalized_hash(context[stickiness], activation_group)
-        else:
-            # This also handles the stickiness == random scenario.
+        elif stickiness == "random":
             calculated_percentage = self.random_hash()
+        else:
+            calculated_percentage = normalized_hash(context[stickiness], activation_group)
 
         return percentage > 0 and calculated_percentage <= percentage

--- a/UnleashClient/variants/Variants.py
+++ b/UnleashClient/variants/Variants.py
@@ -36,7 +36,7 @@ class Variants:
     @staticmethod
     def _get_seed(context: dict, stickiness_selector: str = "default") -> str:
         """Grabs seed value from context."""
-        seed = str(random.random() * 10000)
+        seed = ""
 
         if stickiness_selector == "default":
             if 'userId' in context:
@@ -45,7 +45,11 @@ class Variants:
                 seed = context['sessionId']
             elif 'remoteAddress' in context:
                 seed = context['remoteAddress']
-        elif stickiness_selector in context.keys():
+            else:
+                seed = str(random.random() * 10000)
+        elif stickiness_selector == 'random':
+            seed = str(random.random() * 10000)
+        else:
             seed = context[stickiness_selector]
 
         return seed

--- a/tests/specification_tests/test_10_flexible_rollout.py
+++ b/tests/specification_tests/test_10_flexible_rollout.py
@@ -197,7 +197,7 @@ def test_feature_55sessionid_disabled(unleash_client):
 @responses.activate
 def test_feature_55_nouserdisabled(unleash_client):
     """
-    Feature.flexibleRollout.userId.55 should be disabled
+    Feature.flexibleRollout.userId.55 should be disabled if no userId in context
     """
     # Set up API
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)


### PR DESCRIPTION
# Description

#145 inadvertently introduced intermittent failures in FlexibleRollout strategy and Varient specification tests when context field (i.e. `userId`) was not present in the context.  (Basically, it would "fall through" to random seed instead of erroring and receiving the default value).

In addition, if the API does not have a stickiness level, we will default to `default`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules