### PR TITLE
fix: add authorization headers to getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ pip install UnleashClient
 
 ```
 from UnleashClient import UnleashClient
-client = UnleashClient("https://unleash.herokuapp.com/api", "My Program")
+client = UnleashClient(
+    url="https://unleash.herokuapp.com",
+    app_name="my-python-app",
+    custom_headers={'Authorization': '<API token>'})
 client.initialize_client()
 ```
 


### PR DESCRIPTION
This to comply with v4 requirements. 