### PR TITLE
Exclude test package from dist & wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=readme(),
     long_description_content_type="text/markdown",
     url='https://github.com/Unleash/unleash-client-python',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=["requests", "fcache", "mmh3", "apscheduler"],
     tests_require=['pytest', "mimesis", "responses", 'pytest-mock'],
     zip_safe=False,


### PR DESCRIPTION
# Description

Installing unleash-client-python currently installs a "tests" package to site-packages, which causes issues for running unit-tests locally in projects that use the unleash client.

Fixes # (issue)
Stop publishing tests folder
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] Integration tests / Manual Tests
Run  make build-local.  Check if tests folder is excluded in dist/UnleashClient-4.2.0-py2-none-any.whl & dist/UnleashClient-4.2.0.tar.gz

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
