### PR TITLE
Configure log level of verbose messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ custom_headers | Custom headers to send to Unleash. | N | Dictionary | {} |
 custom_strategies | Custom strategies you'd like UnleashClient to support. | N | Dictionary | {} |
 cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset | 
 project_name | Unleash project Id to load feature flags from | N | Str | "" |
-caution_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
+verbose_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
 
 ### Checking if a feature is enabled
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ custom_headers | Custom headers to send to Unleash. | N | Dictionary | {} |
 custom_strategies | Custom strategies you'd like UnleashClient to support. | N | Dictionary | {} |
 cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset | 
 project_name | Unleash project Id to load feature flags from | N | Str | "" |
+caution_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
 
 ### Checking if a feature is enabled
 

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -30,7 +30,8 @@ class UnleashClient:
                  custom_options: Optional[dict] = None,
                  custom_strategies: Optional[dict] = None,
                  cache_directory: str = None,
-                 project_name: str = None) -> None:
+                 project_name: str = None,
+                 caution_log_level: int = 30) -> None:
         """
         A client for the Unleash feature toggle system.
 
@@ -45,6 +46,7 @@ class UnleashClient:
         :param custom_options: Default requests parameters, optional & defaults to empty.
         :param custom_strategies: Dictionary of custom strategy names : custom strategy objects
         :param cache_directory: Location of the cache directory. When unset, FCache will determine the location
+        :param caution_log_level: Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails.
         """
         custom_headers = custom_headers or {}
         custom_options = custom_options or {}
@@ -66,6 +68,7 @@ class UnleashClient:
             "environment": self.unleash_environment
         }
         self.unleash_project_name = project_name
+        self.unleash_caution_log_level = caution_log_level
 
         # Class objects
         self.cache = FileCache(self.unleash_instance_id, app_cache_dir=cache_directory)
@@ -198,12 +201,12 @@ class UnleashClient:
             try:
                 return self.features[feature_name].is_enabled(context)
             except Exception as excep:
-                LOGGER.warning("Returning default value for feature: %s", feature_name)
-                LOGGER.warning("Error checking feature flag: %s", excep)
+                LOGGER.log(self.unleash_caution_log_level, "Returning default value for feature: %s", feature_name)
+                LOGGER.log(self.unleash_caution_log_level, "Error checking feature flag: %s", excep)
                 return self._get_fallback_value(fallback_function, feature_name, context)
         else:
-            LOGGER.warning("Returning default value for feature: %s", feature_name)
-            LOGGER.warning("Attempted to get feature_flag %s, but client wasn't initialized!", feature_name)
+            LOGGER.log(self.unleash_caution_log_level, "Returning default value for feature: %s", feature_name)
+            LOGGER.log(self.unleash_caution_log_level, "Attempted to get feature_flag %s, but client wasn't initialized!", feature_name)
             return self._get_fallback_value(fallback_function, feature_name, context)
 
     # pylint: disable=broad-except
@@ -227,10 +230,10 @@ class UnleashClient:
             try:
                 return self.features[feature_name].get_variant(context)
             except Exception as excep:
-                LOGGER.warning("Returning default flag/variation for feature: %s", feature_name)
-                LOGGER.warning("Error checking feature flag variant: %s", excep)
+                LOGGER.log(self.unleash_caution_log_level, "Returning default flag/variation for feature: %s", feature_name)
+                LOGGER.log(self.unleash_caution_log_level, "Error checking feature flag variant: %s", excep)
                 return DISABLED_VARIATION
         else:
-            LOGGER.warning("Returning default flag/variation for feature: %s", feature_name)
-            LOGGER.warning("Attempted to get feature flag/variation %s, but client wasn't initialized!", feature_name)
+            LOGGER.log(self.unleash_caution_log_level, "Returning default flag/variation for feature: %s", feature_name)
+            LOGGER.log(self.unleash_caution_log_level, "Attempted to get feature flag/variation %s, but client wasn't initialized!", feature_name)
             return DISABLED_VARIATION

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -31,7 +31,7 @@ class UnleashClient:
                  custom_strategies: Optional[dict] = None,
                  cache_directory: str = None,
                  project_name: str = None,
-                 caution_log_level: int = 30) -> None:
+                 verbose_log_level: int = 30) -> None:
         """
         A client for the Unleash feature toggle system.
 
@@ -46,7 +46,7 @@ class UnleashClient:
         :param custom_options: Default requests parameters, optional & defaults to empty.
         :param custom_strategies: Dictionary of custom strategy names : custom strategy objects
         :param cache_directory: Location of the cache directory. When unset, FCache will determine the location
-        :param caution_log_level: Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails.
+        :param verbose_log_level: Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails.
         """
         custom_headers = custom_headers or {}
         custom_options = custom_options or {}
@@ -68,7 +68,7 @@ class UnleashClient:
             "environment": self.unleash_environment
         }
         self.unleash_project_name = project_name
-        self.unleash_caution_log_level = caution_log_level
+        self.unleash_verbose_log_level = verbose_log_level
 
         # Class objects
         self.cache = FileCache(self.unleash_instance_id, app_cache_dir=cache_directory)
@@ -201,12 +201,12 @@ class UnleashClient:
             try:
                 return self.features[feature_name].is_enabled(context)
             except Exception as excep:
-                LOGGER.log(self.unleash_caution_log_level, "Returning default value for feature: %s", feature_name)
-                LOGGER.log(self.unleash_caution_log_level, "Error checking feature flag: %s", excep)
+                LOGGER.log(self.unleash_verbose_log_level, "Returning default value for feature: %s", feature_name)
+                LOGGER.log(self.unleash_verbose_log_level, "Error checking feature flag: %s", excep)
                 return self._get_fallback_value(fallback_function, feature_name, context)
         else:
-            LOGGER.log(self.unleash_caution_log_level, "Returning default value for feature: %s", feature_name)
-            LOGGER.log(self.unleash_caution_log_level, "Attempted to get feature_flag %s, but client wasn't initialized!", feature_name)
+            LOGGER.log(self.unleash_verbose_log_level, "Returning default value for feature: %s", feature_name)
+            LOGGER.log(self.unleash_verbose_log_level, "Attempted to get feature_flag %s, but client wasn't initialized!", feature_name)
             return self._get_fallback_value(fallback_function, feature_name, context)
 
     # pylint: disable=broad-except
@@ -230,10 +230,10 @@ class UnleashClient:
             try:
                 return self.features[feature_name].get_variant(context)
             except Exception as excep:
-                LOGGER.log(self.unleash_caution_log_level, "Returning default flag/variation for feature: %s", feature_name)
-                LOGGER.log(self.unleash_caution_log_level, "Error checking feature flag variant: %s", excep)
+                LOGGER.log(self.unleash_verbose_log_level, "Returning default flag/variation for feature: %s", feature_name)
+                LOGGER.log(self.unleash_verbose_log_level, "Error checking feature flag variant: %s", excep)
                 return DISABLED_VARIATION
         else:
-            LOGGER.log(self.unleash_caution_log_level, "Returning default flag/variation for feature: %s", feature_name)
-            LOGGER.log(self.unleash_caution_log_level, "Attempted to get feature flag/variation %s, but client wasn't initialized!", feature_name)
+            LOGGER.log(self.unleash_verbose_log_level, "Returning default flag/variation for feature: %s", feature_name)
+            LOGGER.log(self.unleash_verbose_log_level, "Attempted to get feature flag/variation %s, but client wasn't initialized!", feature_name)
             return DISABLED_VARIATION

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 ## Next version
 
+## Upcoming
+* (Minor) Allow users to specify log-level for when `is_enabled()` or `get_varients()` calls fail.
+
 ## v4.2.0
 * (Minor) Support custom stickiness for FlexibleRollout strategy and variants.
 

--- a/docs/unleashclient.md
+++ b/docs/unleashclient.md
@@ -23,7 +23,7 @@ custom_options | Custom arguments for requests package. | N | Dictionary | {}
 custom_strategies | Custom strategies you'd like UnleashClient to support. | N | Dictionary | {} |
 cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset | 
 project_name | Unleash project Id to load feature flags from | N | Str | "" |
-caution_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
+verbose_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
 
 ### `initialize_client()`
 Initializes client and starts communication with central unleash server(s).

--- a/docs/unleashclient.md
+++ b/docs/unleashclient.md
@@ -23,6 +23,7 @@ custom_options | Custom arguments for requests package. | N | Dictionary | {}
 custom_strategies | Custom strategies you'd like UnleashClient to support. | N | Dictionary | {} |
 cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset | 
 project_name | Unleash project Id to load feature flags from | N | Str | "" |
+caution_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
 
 ### `initialize_client()`
 Initializes client and starts communication with central unleash server(s).

--- a/tests/integration_tests/integration_unleashhosted.py
+++ b/tests/integration_tests/integration_unleashhosted.py
@@ -47,7 +47,7 @@ my_client = UnleashClient(
     app_name="pyIvan",
     custom_headers={'Authorization': '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d'},
     custom_strategies=custom_strategies_dict,
-    caution_log_level=10
+    verbose_log_level=10
 )
 
 my_client.initialize_client()

--- a/tests/integration_tests/integration_unleashhosted.py
+++ b/tests/integration_tests/integration_unleashhosted.py
@@ -46,7 +46,8 @@ my_client = UnleashClient(
     environment="staging",
     app_name="pyIvan",
     custom_headers={'Authorization': '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d'},
-    custom_strategies=custom_strategies_dict
+    custom_strategies=custom_strategies_dict,
+    caution_log_level=10
 )
 
 my_client.initialize_client()


### PR DESCRIPTION
# Description

Allows users to configure log level of verbose messaging (mainly around failures to check feature flags or varients).

Fixes #150 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules