### PR TITLE
v4.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.0
+current_version = 4.3.0
 commit = True
 tag = True
 message = Automatic version bump via bumpversion.

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -1,6 +1,6 @@
 # Library
 SDK_NAME = "unleash-client-python"
-SDK_VERSION = "4.2.0"
+SDK_VERSION = "4.3.0"
 REQUEST_TIMEOUT = 30
 METRIC_LAST_SENT_TIME = "mlst"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 ## Next version
 
-## Upcoming
+## v4.3.0
 * (Minor) `initialize_client()` will raise exception if UnleashClient is configured with an invalid URL.
 * (Minor) Exclude test package from dist & wheel.  Thanks @ameyajoshi99!
 * (Minor) Allow users to specify log-level for when `is_enabled()` or `get_varients()` calls fail.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='UnleashClient',
-    version='4.2.0',
+    version='4.3.0',
     author='Ivan Lee',
     author_email='ivanklee86@gmail.com',
     description='Python client for the Unleash feature toggle system!',


### PR DESCRIPTION
* (Minor) `initialize_client()` will raise exception if UnleashClient is configured with an invalid URL.
* (Minor) Exclude test package from dist & wheel.  Thanks @ameyajoshi99!
* (Minor) Allow users to specify log-level for when `is_enabled()` or `get_varients()` calls fail.