### PR TITLE
Include py.typed marker in sdist/wheel packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include UnleashClient/py.typed

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     long_description_content_type="text/markdown",
     url='https://github.com/Unleash/unleash-client-python',
     packages=find_packages(exclude=["tests*"]),
+    package_data={"UnleashClient": ["py.typed"]},
     install_requires=["requests", "fcache", "mmh3", "apscheduler"],
     tests_require=['pytest', "mimesis", "responses", 'pytest-mock'],
     zip_safe=False,


### PR DESCRIPTION
This marks the package as ‘typing friendly’ and enables tools like mypy
to actually type check code using this library.

Closes #161.
