### PR TITLE
docs: Add some details for running the client under wsgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,13 @@ print(variant)
 ```
 
 For more information about variants, see the [Variant documentation](https://unleash.github.io/docs/toggle_variants).
+
+
+### Running in a WSGI Context
+
+
+WSGI is a faily common way of running webserver applications for both Flask and Django, if you're running in WSGI there are a few caveats that you should be aware of:
+
+* By default WSGI removes the GIL and disables threading, this SDK requires threads to work for the background updates of feature toggles, without it, your application will run but will not reflect updates to state of feature toggles when changed. To get around this, you'll need to enable threading, you can do this by setting enable-threads in your WSGI configuration
+
+* If you need to scale out your application with multiple processes by setting the processes flag in your WSGI configuration, note that this can cause issues with updates as well, in order to resolve these, you'll also need to enable the lazy-apps flag in WSGI, this will cause each process to trigger a clean reload of your application. More information on the rammifcations of this change can be found [here](https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html#preforking-vs-lazy-apps-vs-lazy)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ disable_metrics | Disables sending metrics to Unleash server. | N | Boolean | F 
 disable_registration | Disables registration with Unleash server. | N | Boolean | F |
 custom_headers | Custom headers to send to Unleash. | N | Dictionary | {} |
 custom_strategies | Custom strategies you'd like UnleashClient to support. | N | Dictionary | {} |
-cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset | 
+cache_directory | Location of the cache directory. When unset, FCache will determine the location | N | Str | Unset |
 project_name | Unleash project Id to load feature flags from | N | Str | "" |
 verbose_log_level | Numerical log level (https://docs.python.org/3/library/logging.html#logging-levels) for cases where checking a feature flag fails. | N | Integer | 30 (Warning) |
 
@@ -118,7 +118,7 @@ For more information about variants, see the [Variant documentation](https://unl
 ### Running in a WSGI Context
 
 
-WSGI is a faily common way of running webserver applications for both Flask and Django, if you're running in WSGI there are a few caveats that you should be aware of:
+WSGI is a fairly common way of running webserver applications for both Flask and Django, if you're running in WSGI there are a few caveats that you should be aware of:
 
 * By default WSGI removes the GIL and disables threading, this SDK requires threads to work for the background updates of feature toggles, without it, your application will run but will not reflect updates to state of feature toggles when changed. To get around this, you'll need to enable threading, you can do this by setting enable-threads in your WSGI configuration
 


### PR DESCRIPTION
# Description

This is just a documentation update that provides some context for easy to fall into traps for running the client in wsgi

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings