### PR TITLE
docs: Link to flask sdk in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install UnleashClient
 
 ## Related Work
 
-If you're looking into running Unleash from Flask, you might want to take a look at the [Unleash Flask SDK](https://github.com/Unleash/Flask-Unleash), which uses this project but handles some of the boilerplate code for you.
+If you're looking into running Unleash from Flask, you might want to take a look at [_Flask-Unleash_, the Unleash Flask extension](https://github.com/Unleash/Flask-Unleash). The extension builds upon this SDK to reduce the amount of boilerplate code you need to write to integrate with Flask. Of course, if you'd rather use this package directly, that will work too.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Check out the package on [Pypi](https://pypi.org/project/UnleashClient/)!
 pip install UnleashClient
 ```
 
-## Related Work
+## For Flask Users
 
 If you're looking into running Unleash from Flask, you might want to take a look at [_Flask-Unleash_, the Unleash Flask extension](https://github.com/Unleash/Flask-Unleash). The extension builds upon this SDK to reduce the amount of boilerplate code you need to write to integrate with Flask. Of course, if you'd rather use this package directly, that will work too.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Check out the package on [Pypi](https://pypi.org/project/UnleashClient/)!
 pip install UnleashClient
 ```
 
+## Related Work
+
+If you're looking into running Unleash from Flask, you might want to take a look at the [Unleash Flask SDK](https://github.com/Unleash/Flask-Unleash), which uses this project but handles some of the boilerplate code for you.
+
 ## Usage
 
 ### Initialization
@@ -35,7 +39,7 @@ client = UnleashClient(
     url="https://unleash.herokuapp.com",
     app_name="my-python-app",
     custom_headers={'Authorization': '<API token>'})
-    
+
 client.initialize_client()
 ```
 


### PR DESCRIPTION
This is just a patch to the docs to reference the Flask SDK project, which consumes this project. We're looking to doing this because we've had a number of people get great value out of that project and then ask why the docs here didn't point to it 