### PR TITLE
Prepare for v5.0.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.1
+current_version = 5.0.0
 commit = True
 tag = True
 message = Automatic version bump via bumpversion.

--- a/UnleashClient/constants.py
+++ b/UnleashClient/constants.py
@@ -1,6 +1,6 @@
 # Library
 SDK_NAME = "unleash-client-python"
-SDK_VERSION = "4.4.1"
+SDK_VERSION = "5.0.0"
 REQUEST_TIMEOUT = 30
 METRIC_LAST_SENT_TIME = "mlst"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 ## Next version
 
+## v5.0.0
+* (Breaking) Modify client initialization to allow jitter configuration on refresh/background refresh intervals.  May break code when parameters to UnleashClient are not used as keyword arguments.  Thanks @dryobates and @jstolarski!
+* (Major) If client is already initialized, calling `initialize_client()` again won't re-run initialization.
+* (Minor) Support HTTP 304 on `/client/feature` endpoint.
+* (Minor) Rename `master` to `main`.
+* (Documentation) Document running UnleashClient in uWSGI.  Thanks @sighphyre!
+* (Documentation) Fix links and formatting.  Thanks @thomasheartman & @sighphyre!
+
 ## v4.4.1
 * (Minor) Include py.typed to mark package as type-friendly!  Thanks @wbolster!
 * (Minor) Fix API url sanitization.  Thanks @romulorosa!

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='UnleashClient',
-    version='4.4.1',
+    version='5.0.0',
     author='Ivan Lee',
     author_email='ivanklee86@gmail.com',
     description='Python client for the Unleash feature toggle system!',


### PR DESCRIPTION
Changelog:
```
* (Breaking) Modify client initialization to allow jitter configuration on refresh/background refresh intervals.  May break code when parameters to UnleashClient are not used as keyword arguments.  Thanks @dryobates and @jstolarski!
* (Major) If client is already initialized, calling `initialize_client()` again won't re-run initialization.
* (Minor) Support HTTP 304 on `/client/feature` endpoint.
* (Minor) Rename `master` to `main`.
* (Documentation) Document running UnleashClient in uWSGI.  Thanks @sighphyre!
* (Documentation) Fix links and formatting.  Thanks @thomasheartman & @sighphyre!
```