### PR TITLE
fix: do not try to parse unmodified feature flags

### DIFF
--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -59,6 +59,9 @@ def get_feature_toggles(url: str,
         if 'etag' in resp.headers.keys():
             etag = resp.headers['etag']
 
+        if resp.status_code == 304:
+            return None, etag
+            
         return resp.json(), etag
     except Exception as exc:
         LOGGER.exception("Unleash Client feature fetch failed due to exception: %s", exc)


### PR DESCRIPTION
# Description

As mentioned in #185 the client should not attempt to parse 
the request body if the returned http status code was 304 as 
servers like gitlab send an empty response body in this case.

The result from get_feature_toggles gets ignored in
fetch_and_load_features if None is returned.


Fixes #185 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules