### PR TITLE
2 modes for running Unleash integration

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -10,6 +10,7 @@ from UnleashClient.periodic_tasks import fetch_and_load_features, aggregate_and_
 from UnleashClient.strategies import ApplicationHostname, Default, GradualRolloutRandom, \
     GradualRolloutSessionId, GradualRolloutUserId, UserWithId, RemoteAddress, FlexibleRollout
 from UnleashClient.constants import METRIC_LAST_SENT_TIME, DISABLED_VARIATION, ETAG
+from UnleashClient.loader import load_features
 from .utils import LOGGER
 from .deprecation_warnings import strategy_v2xx_deprecation_check
 from .cache import BaseCache, FileCache
@@ -109,7 +110,7 @@ class UnleashClient:
         # Client status
         self.is_initialized = False
 
-    def initialize_client(self) -> None:
+    def initialize_client(self, fetch_toggles: bool = True) -> None:
         """
         Initializes client and starts communication with central unleash server(s).
 
@@ -118,6 +119,11 @@ class UnleashClient:
         * Client registration
         * Provisioning poll
         * Stats poll
+
+        If `fetch_toggles` is `False`, feature toggle polling will be turned off
+        and instead the client will only load features from the cache. This is
+        usually used to cater the multi-process setups, e.g. Django, Celery,
+        etc.
 
         This will raise an exception on registration if the URL is invalid. It is done automatically if called inside a context manager as in:
 
@@ -134,18 +140,6 @@ class UnleashClient:
         if not self.is_initialized:
             try:
                 # Setup
-                fl_args = {
-                    "url": self.unleash_url,
-                    "app_name": self.unleash_app_name,
-                    "instance_id": self.unleash_instance_id,
-                    "custom_headers": self.unleash_custom_headers,
-                    "custom_options": self.unleash_custom_options,
-                    "cache": self.cache,
-                    "features": self.features,
-                    "strategy_mapping": self.strategy_mapping,
-                    "project": self.unleash_project_name
-                }
-
                 metrics_args = {
                     "url": self.unleash_url,
                     "app_name": self.unleash_app_name,
@@ -162,16 +156,36 @@ class UnleashClient:
                                     self.unleash_metrics_interval, self.unleash_custom_headers,
                                     self.unleash_custom_options, self.strategy_mapping)
 
-                fetch_and_load_features(**fl_args)  # type: ignore
+                if fetch_toggles:
+                    job_args = {
+                        "url": self.unleash_url,
+                        "app_name": self.unleash_app_name,
+                        "instance_id": self.unleash_instance_id,
+                        "custom_headers": self.unleash_custom_headers,
+                        "custom_options": self.unleash_custom_options,
+                        "cache": self.cache,
+                        "features": self.features,
+                        "strategy_mapping": self.strategy_mapping,
+                        "project": self.unleash_project_name,
+                    }
+                    job_func: Callable = fetch_and_load_features
+                else:
+                    job_args = {
+                        "cache": self.cache,
+                        "feature_toggles": self.features,
+                        "strategy_mapping": self.strategy_mapping,
+                    }
+                    job_func = load_features
 
+                job_func(**job_args)  # type: ignore
                 # Start periodic jobs
                 self.scheduler.start()
-                self.fl_job = self.scheduler.add_job(fetch_and_load_features,
+                self.fl_job = self.scheduler.add_job(job_func,
                                                      trigger=IntervalTrigger(
                                                          seconds=int(self.unleash_refresh_interval),
                                                          jitter=self.unleash_refresh_jitter,
                                                      ),
-                                                     kwargs=fl_args)
+                                                     kwargs=job_args)
 
                 if not self.unleash_disable_metrics:
                     self.metric_job = self.scheduler.add_job(aggregate_and_send_metrics,


### PR DESCRIPTION
# Description

Usually Unleash Python SDK would do 2 things periodically:

1. fetch feature toggles from the Unleash server,
2. load them into the local [Cache](https://github.com/Unleash/unleash-client-python/blob/4c7bc98e7919f5f3ae91ca1c732337be61b2d17b/UnleashClient/cache.py#L7).

Then SDK uses the toggles from the cache.

However, when a service (or application) is using multiprocessing for concurrency, such model creates higher loads on Unleash than ideal:

1. now each separate process has it's own cache and is fetching the toggles. This is somewhat touched at https://github.com/Unleash/unleash-client-python/issues/105
2. Instead, we'd like one process to fetch the toggles and other process load them.

To cater such concurrency models this PR allows to run Unleash SDK in 2 modes:
1. The regular way: fetch + load: `UnleashClient().initialize_client()`
2. Only load the toggles from the cache, but do not fetch them from the server: `UnleashClient().initialize_client(fetch_toggles=False)`

Obviously, this is backwards compatible.

Now this by itself doesn't allow to use this SDK in multiprocess environment, however in conjuction with [diskcache](https://pypi.org/project/diskcache/) as mentioned in [this issue](https://github.com/Unleash/unleash-client-python/issues/194) seems to operate fine.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

The changes are quite trivial, hence only manual testing.

- [ ] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests
- [X] Manual

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules