### PR TITLE
docs(readme): update `default_value`, fix toggle naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ For more information about configuring `UnleashClient`, check out the [docs](htt
 
 A check of a simple toggle:
 ```Python
-client.is_enabled("My Toggle")
+client.is_enabled("my_toggle")
 ```
 
 Specifying a default value:
 ```Python
-client.is_enabled("My Toggle", default_value=True)
+client.is_enabled("my_toggle", default_value=True)
 ```
 
 Supplying application context:
 ```Python
 app_context = {"userId": "test@email.com"}
-client.is_enabled("User ID Toggle", app_context)
+client.is_enabled("user_id_toggle", app_context)
 ```
 
 For more information about usage, see the [Usage documentation](https://docs.getunleash.io/unleash-client-python/usage.html).
@@ -71,7 +71,7 @@ Checking for a variant:
 ```python
 context = {'userId': '2'}  # Context must have userId, sessionId, or remoteAddr.  If none are present, distribution will be random.
 
-variant = client.get_variant("MyvariantToggle", context)
+variant = client.get_variant("variant_toggle", context)
 
 print(variant)
 > {

--- a/README.md
+++ b/README.md
@@ -52,9 +52,19 @@ A check of a simple toggle:
 client.is_enabled("my_toggle")
 ```
 
-Specifying a default value:
+You can specify a fallback function for cases where the client doesn't recognize the toggle by using the `fallback_function` keyword argument:
+
 ```Python
-client.is_enabled("my_toggle", default_value=True)
+def custom_fallback(feature_name: str, context: dict) -> bool:
+    return True
+
+client.is_enabled("my_toggle", fallback_function=custom_fallback)
+```
+
+You can also use the `fallback_function` argument to replace the obsolete `default_value` by using a lambda that ignores its inputs:
+
+```Python
+client.is_enabled("my_toggle", fallback_function=lambda feature_name, context: True)
 ```
 
 Supplying application context:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,40 +26,34 @@ A check of a simple toggle:
 
 .. code-block:: python
 
-    client.is_enabled("My Toggle")
-
-
-Specifying a default value:
-
-.. code-block:: python
-
-    def custom_fallback(feature_name: str, context: dict) -> bool:
-        return True
-        
-    client.is_enabled("My Toggle", fallback_function=custom_fallback)
-
+    client.is_enabled("my_toggle")
 
 Supplying application context:
 
 .. code-block:: python
 
     app_context = {"userId": "test@email.com"}
-    client.is_enabled("User ID Toggle", app_context)
+    client.is_enabled("user_id_toggle", app_context)
 
-Supplying a fallback function:
+You can specify a fallback function for cases where the client doesn't recognize the toggle by using the `fallback_function` keyword argument:
 
 .. code-block:: python
 
     def custom_fallback(feature_name: str, context: dict) -> bool:
         return True
 
-    client.is_enabled("My Toggle", fallback_function=custom_fallback)
+    client.is_enabled("my_toggle", fallback_function=custom_fallback)
 
 Notes:
 
 - Must accept the fature name and context as an argument.
 - Client will evaluate the fallback function only if exception occurs when calling the ``is_enabled()`` method i.e. feature flag not found or other general exception.
-- If both a ``default_value`` and ``fallback_function`` are supplied, client will define the default value by ``OR`` ing the default value and the output of the fallback function.
+
+You can also use the `fallback_function` argument to replace the obsolete `default_value` by using a lambda that ignores its inputs:
+
+.. code-block:: python
+
+    client.is_enabled("my_toggle", fallback_function=lambda feature_name, context: True)
 
 
 Getting a variant
@@ -71,7 +65,7 @@ Checking for a variant:
 
     context = {'userId': '2'}  # Context must have userId, sessionId, or remoteAddr.  If none are present, distribution will be random.
 
-    variant = client.get_variant("MyvariantToggle", context)
+    variant = client.get_variant("variant_toggle", context)
 
     print(variant)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,7 +35,7 @@ Supplying application context:
     app_context = {"userId": "test@email.com"}
     client.is_enabled("user_id_toggle", app_context)
 
-You can specify a fallback function for cases where the client doesn't recognize the toggle by using the `fallback_function` keyword argument:
+You can specify a fallback function for cases where the client doesn't recognize the toggle by using the ``fallback_function`` keyword argument:
 
 .. code-block:: python
 
@@ -49,7 +49,7 @@ Notes:
 - Must accept the fature name and context as an argument.
 - Client will evaluate the fallback function only if exception occurs when calling the ``is_enabled()`` method i.e. feature flag not found or other general exception.
 
-You can also use the `fallback_function` argument to replace the obsolete `default_value` by using a lambda that ignores its inputs:
+You can also use the ``fallback_function`` argument to replace the obsolete ``default_value`` by using a lambda that ignores its inputs:
 
 .. code-block:: python
 


### PR DESCRIPTION
# Description

This PR adds the following changes to the readme file:

- Toggle names are changed to remove spaces. Unleash doesn't support spaces in feature toggle names (names must be url-friendly), so I've instead lowercased them and used underscores as their separators.

- Replace the `default_value` example with two examples of using `fallback_function`: one with a named function, and one with a lambda to replace the `default_value`.

This has some relation with #207 and #100. It doesn't close any issues (as far as I'm aware), but it does seem to be some leftover changes that were just never cleaned up.

I am, of course, happy to make any changes to the PR if you have any suggestions.

## Type of change

Please delete options that are not relevant.

- [x] Readme update.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules