### PR TITLE
fix: removes docstring ref to `default_value` argument.

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -245,7 +245,6 @@ class UnleashClient:
 
         :param feature_name: Name of the feature
         :param context: Dictionary with context (e.g. IPs, email) for feature toggle.
-        :param default_value: Allows override of default value. (DEPRECIATED, used fallback_function instead!)
         :param fallback_function: Allows users to provide a custom function to set default value.
         :return: Feature flag result
         """


### PR DESCRIPTION
# Description

This argument was made obsolete a while ago and makes the client crash
when used.

-------

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has not been tested yet. It seems like straight forward doc-update to me, but if there are ways to verify it, I'm more than happy to.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules