### PR TITLE
move to mmhash3 library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 importlib_metadata
 requests
 fcache
-mmh3
+mmhash3
 APScheduler
 python-dateutil
 semver

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "requests",
         "fcache",
-        "mmh3",
+        "mmhash3",
         "apscheduler",
         "importlib_metadata",
         "python-dateutil",


### PR DESCRIPTION
This moves the murmur hash library to https://github.com/Fokko/mmhash3. The original mmh3 library hasn't been maintained in 2 years and does not have prebuilt wheels for Python 3.10+, which is causing pain for users.