### PR TITLE
Feat/block multiple constructions

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -22,7 +22,7 @@ from .deprecation_warnings import strategy_v2xx_deprecation_check
 from .cache import BaseCache, FileCache
 
 
-class InstanceAllowType:
+class InstanceAllowType(Enum):
     BLOCK = 1,
     WARN = 2,
     SILENTLY_ALLOW = 3

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -3,8 +3,6 @@ import warnings
 import random
 import string
 from datetime import datetime, timezone
-from enum import Enum
-from threading import RLock
 from typing import Callable, Optional
 from apscheduler.job import Job
 from apscheduler.schedulers.base import BaseScheduler
@@ -17,39 +15,9 @@ from UnleashClient.strategies import ApplicationHostname, Default, GradualRollou
     GradualRolloutSessionId, GradualRolloutUserId, UserWithId, RemoteAddress, FlexibleRollout
 from UnleashClient.constants import METRIC_LAST_SENT_TIME, DISABLED_VARIATION, ETAG
 from UnleashClient.loader import load_features
-from .utils import LOGGER
+from .utils import LOGGER, InstanceCounter, InstanceAllowType
 from .deprecation_warnings import strategy_v2xx_deprecation_check
 from .cache import BaseCache, FileCache
-
-
-class InstanceAllowType(Enum):
-    BLOCK = 1
-    WARN = 2
-    SILENTLY_ALLOW = 3
-
-
-class InstanceCounter:
-    def __init__(self):
-        self.instances = {}
-        self.lock = RLock()
-
-    def __contains__(self, key):
-        with self.lock:
-            return key in self.instances
-
-    def _reset(self):
-        self.instances = {}
-
-    def count(self, key):
-        with self.lock:
-            return self.instances.get(key) or 0
-
-    def increment(self, key):
-        with self.lock:
-            if key in self:
-                self.instances[key] += 1
-            else:
-                self.instances[key] = 1
 
 
 INSTANCES = InstanceCounter()

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -340,7 +340,7 @@ class UnleashClient:
             if multiple_instance_mode == InstanceAllowType.BLOCK:
                 raise Exception(msg)
             if multiple_instance_mode == InstanceAllowType.WARN:
-                LOGGER.warning(msg)
+                LOGGER.error(msg)
         INSTANCES.increment(identifier)
 
     def __get_identifier(self):

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -76,7 +76,7 @@ class UnleashClient:
     :param cache: Custom cache implementation that extends UnleashClient.cache.BaseCache.  When unset, UnleashClient will use Fcache.
     :param scheduler: Custom APScheduler object.  Use this if you want to customize jobstore or executors.  When unset, UnleashClient will create it's own scheduler.
     :param scheduler_executor: Name of APSCheduler executor to use if using a custom scheduler.
-    :param multiple_instance_mode: Determines how multiple instances being instantiated is handled by the SDK, when set to InstanceAllowType.BLOCK, the client constructor will fail when more than one instance is detected, when set to InstanceAllowType.WARN, multiple instances will be allowed but log a warning, when set to InstanceAllowType.SILENTLY_ALLOW, no warning or failure will be raised when instantiating multiple instances of the client. Defaults to InstanceAllowType.BLOCK
+    :param multiple_instance_mode: Determines how multiple instances being instantiated is handled by the SDK, when set to InstanceAllowType.BLOCK, the client constructor will fail when more than one instance is detected, when set to InstanceAllowType.WARN, multiple instances will be allowed but log a warning, when set to InstanceAllowType.SILENTLY_ALLOW, no warning or failure will be raised when instantiating multiple instances of the client. Defaults to InstanceAllowType.WARN
     """
     def __init__(self,
                  url: str,
@@ -98,7 +98,7 @@ class UnleashClient:
                  cache: Optional[BaseCache] = None,
                  scheduler: Optional[BaseScheduler] = None,
                  scheduler_executor: Optional[str] = None,
-                 deny_multiple_instances: InstanceAllowType = InstanceAllowType.BLOCK) -> None:
+                 multiple_instance_mode: InstanceAllowType = InstanceAllowType.WARN) -> None:
         custom_headers = custom_headers or {}
         custom_options = custom_options or {}
         custom_strategies = custom_strategies or {}
@@ -127,9 +127,9 @@ class UnleashClient:
         identifier = self.__get_identifier()
         if identifier in INSTANCES:
             msg = f"You already have {INSTANCES.count(identifier)} instance(s) configured for this config: {identifier}, please double check the code where this client is being instantiated."
-            if deny_multiple_instances == InstanceAllowType.BLOCK:
+            if multiple_instance_mode == InstanceAllowType.BLOCK:
                 raise Exception(msg)
-            elif deny_multiple_instances == InstanceAllowType.WARN:
+            elif multiple_instance_mode == InstanceAllowType.WARN:
                 LOGGER.warning(msg)
         INSTANCES.increment(identifier)
 

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -1,9 +1,9 @@
 import logging
 from enum import Enum
+from threading import RLock
 from typing import Any
 import mmh3  # pylint: disable=import-error
 from requests import Response
-from threading import RLock
 
 LOGGER = logging.getLogger('UnleashClient')
 

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -1,9 +1,41 @@
 import logging
+from enum import Enum
 from typing import Any
 import mmh3  # pylint: disable=import-error
 from requests import Response
+from threading import RLock
 
 LOGGER = logging.getLogger('UnleashClient')
+
+
+class InstanceAllowType(Enum):
+    BLOCK = 1
+    WARN = 2
+    SILENTLY_ALLOW = 3
+
+
+class InstanceCounter:
+    def __init__(self):
+        self.instances = {}
+        self.lock = RLock()
+
+    def __contains__(self, key):
+        with self.lock:
+            return key in self.instances
+
+    def _reset(self):
+        self.instances = {}
+
+    def count(self, key):
+        with self.lock:
+            return self.instances.get(key) or 0
+
+    def increment(self, key):
+        with self.lock:
+            if key in self:
+                self.instances[key] += 1
+            else:
+                self.instances[key] = 1
 
 
 def normalized_hash(identifier: str,

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -7,8 +7,9 @@ import pytest
 import responses
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
-from UnleashClient import UnleashClient, INSTANCES, InstanceAllowType
+from UnleashClient import UnleashClient, INSTANCES
 from UnleashClient.strategies import Strategy
+from UnleashClient.utils import InstanceAllowType
 from tests.utilities.testing_constants import URL, ENVIRONMENT, APP_NAME, INSTANCE_ID, REFRESH_INTERVAL, REFRESH_JITTER, \
     METRICS_INTERVAL, METRICS_JITTER, DISABLE_METRICS, DISABLE_REGISTRATION, CUSTOM_HEADERS, CUSTOM_OPTIONS, PROJECT_NAME, PROJECT_URL, \
     ETAG_VALUE

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 
 [tox]
 envlist = py37,py38,py39,py310
-allowlist_externals = ./get_spec.sh
+allowlist_externals =
+    ./get_spec.sh
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 
 [tox]
 envlist = py37,py38,py39,py310
+allowlist_externals = ./get_spec.sh
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 
 [tox]
 envlist = py37,py38,py39,py310
-allowlist_externals =
-    ./get_spec.sh
 
 [testenv]
 deps = -rrequirements.txt
+allowlist_externals = sh
 commands =
     mypy UnleashClient --install-types --non-interactive
-    ./get-spec.sh
+    sh get-spec.sh
     pylint UnleashClient
     py.test tests/unit_tests
     py.test tests/specification_tests


### PR DESCRIPTION
This introduces a new instance checking concept into the SDK, this is a result of regular misconfigurations across the board with the SDKs, which result in multiple polling instances hammering the server. By default the instance checking will raise a warning if the constructor is called more than once in a process with the same configuration. This also allows the consumer to change this to either not log the warning at all, in rare cases that multiple clients may be correct, or to raise the warning to an error and prevent multiple instantiations at all.