### PR TITLE
chore: disable a few new pylint warnings

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -178,6 +178,7 @@ class UnleashClient:
         """
         # Only perform initialization steps if client is not initialized.
         if not self.is_initialized:
+            # pylint: disable=no-else-raise
             try:
                 # Setup
                 metrics_args = {
@@ -338,6 +339,7 @@ class UnleashClient:
         if identifier in INSTANCES:
             msg = f"You already have {INSTANCES.count(identifier)} instance(s) configured for this config: {identifier}, please double check the code where this client is being instantiated."
             if multiple_instance_mode == InstanceAllowType.BLOCK:
+                # pylint: disable=broad-exception-raised
                 raise Exception(msg)
             if multiple_instance_mode == InstanceAllowType.WARN:
                 LOGGER.error(msg)

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -61,6 +61,7 @@ def get_feature_toggles(url: str,
         if resp.status_code not in [200, 304]:
             log_resp_info(resp)
             LOGGER.warning("Unleash Client feature fetch failed due to unexpected HTTP status code.")
+            # pylint: disable=broad-exception-raised
             raise Exception("Unleash Client feature fetch failed!")
 
         etag = ''


### PR DESCRIPTION
Looks like Pylint got an update and it's now flagging code that's been around for a while. I would agree with these warnings for new code but the stuff that's being flagged is and has been working for a while. I'm proposing we disable these