### PR TITLE
Fix warning scheduler_executor without scheduler

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -139,7 +139,7 @@ class UnleashClient:
                 "If using a custom scheduler, you must specify a executor."
             )
         else:
-            if not scheduler:
+            if not scheduler and scheduler_executor:
                 LOGGER.warning(
                     "scheduler_executor should only be used with a custom scheduler."
                 )


### PR DESCRIPTION
# Description

Removes warning message when Unleash client is initialised without scheduler and scheduler_executor.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
