### PR TITLE
docs(cache): fix typo in docstrings

### DIFF
--- a/UnleashClient/cache.py
+++ b/UnleashClient/cache.py
@@ -67,7 +67,7 @@ class FileCache(BaseCache):
         unleash_client = UnleashClient(
             "https://my.unleash.server.com",
             "HAMSTER_API",
-            cache=cache
+            cache=my_cache
         )
 
     :param name: Name of cache.


### PR DESCRIPTION
# Description
Typo in `Cache` doctstrings

## Type of change
Documentation

# How Has This Been Tested?
N/a

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
