### PR TITLE
Count metrics for non-existing features

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -351,7 +351,9 @@ class UnleashClient:
                 feature_check = feature.is_enabled(context)
 
                 if feature.only_for_metrics:
-                    return self._get_fallback_value(fallback_function, feature_name, context)
+                    return self._get_fallback_value(
+                        fallback_function, feature_name, context
+                    )
 
                 try:
                     if self.unleash_event_callback and feature.impression_data:
@@ -391,7 +393,9 @@ class UnleashClient:
                 # Use the feature's is_enabled method to count the call
                 new_feature.is_enabled(context)
 
-                return self._get_fallback_value(fallback_function, feature_name, context)
+                return self._get_fallback_value(
+                    fallback_function, feature_name, context
+                )
 
         else:
             LOGGER.log(

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -383,13 +383,13 @@ class UnleashClient:
                 )
                 # The feature doesn't exist, so create it to track metrics
                 new_feature = Feature(feature_name, False, [])
-                self.features[feature_name]  = new_feature
+                self.features[feature_name] = new_feature
 
                 # Use the feature's is_enabled method to count the call
-                return new_feature.is_enabled(context,
-                                              self._get_fallback_value(
-                                                  fallback_function, feature_name, context
-                                              ))
+                return new_feature.is_enabled(
+                    context,
+                    self._get_fallback_value(fallback_function, feature_name, context),
+                )
         else:
             LOGGER.log(
                 self.unleash_verbose_log_level,
@@ -459,7 +459,7 @@ class UnleashClient:
 
                 # The feature doesn't exist, so create it to track metrics
                 new_feature = Feature(feature_name, False, [])
-                self.features[feature_name]  = new_feature
+                self.features[feature_name] = new_feature
 
                 # Use the feature's is_enabled method to count the call
                 return new_feature.get_variant(context)

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -468,7 +468,7 @@ class UnleashClient:
                 new_feature = Feature.metrics_only_feature(feature_name)
                 self.features[feature_name] = new_feature
 
-                # Use the feature's is_enabled method to count the call
+                # Use the feature's get_variant method to count the call
                 return new_feature.get_variant(context)
         else:
             LOGGER.log(

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -350,6 +350,9 @@ class UnleashClient:
                 feature = self.features[feature_name]
                 feature_check = feature.is_enabled(context)
 
+                if feature.only_for_metrics:
+                    return self._get_fallback_value(fallback_function, feature_name, context)
+
                 try:
                     if self.unleash_event_callback and feature.impression_data:
                         event = UnleashEvent(
@@ -382,14 +385,14 @@ class UnleashClient:
                     excep,
                 )
                 # The feature doesn't exist, so create it to track metrics
-                new_feature = Feature(feature_name, False, [])
+                new_feature = Feature.metrics_only_feature(feature_name)
                 self.features[feature_name] = new_feature
 
                 # Use the feature's is_enabled method to count the call
-                return new_feature.is_enabled(
-                    context,
-                    self._get_fallback_value(fallback_function, feature_name, context),
-                )
+                new_feature.is_enabled(context)
+
+                return self._get_fallback_value(fallback_function, feature_name, context)
+
         else:
             LOGGER.log(
                 self.unleash_verbose_log_level,
@@ -458,7 +461,7 @@ class UnleashClient:
                 )
 
                 # The feature doesn't exist, so create it to track metrics
-                new_feature = Feature(feature_name, False, [])
+                new_feature = Feature.metrics_only_feature(feature_name)
                 self.features[feature_name] = new_feature
 
                 # Use the feature's is_enabled method to count the call

--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -40,7 +40,7 @@ class Feature:
         self.variant_counts: Dict[str, int] = {}
 
         # Whether the feature exists only for tracking metrics or not.
-        self.only_for_metrics = False;
+        self.only_for_metrics = False
 
     def reset_stats(self) -> None:
         """

--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -39,6 +39,9 @@ class Feature:
         ## { [ variant name ]: number }
         self.variant_counts: Dict[str, int] = {}
 
+        # Whether the feature exists only for tracking metrics or not.
+        self.only_for_metrics = False;
+
     def reset_stats(self) -> None:
         """
         Resets stats after metrics reporting
@@ -119,3 +122,9 @@ class Feature:
 
         self._count_variant(cast(str, variant["name"]))
         return variant
+
+    @staticmethod
+    def metrics_only_feature(feature_name: str):
+        feature = Feature(feature_name, False, [])
+        feature.only_for_metrics = True
+        return feature

--- a/UnleashClient/loader.py
+++ b/UnleashClient/loader.py
@@ -145,6 +145,11 @@ def load_features(
             "impressionData", False
         )
 
+        # If the feature had previously been added to the features list only for
+        # tracking, indicate that it is now a real feature that should be
+        # evaluated properly.
+        feature_for_update.only_for_metrics = False
+
     # Handle creation or deletions
     new_features = list(set(feature_names) - set(feature_toggles.keys()))
 

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -418,7 +418,6 @@ def test_uc_registers_metrics_for_nonexistent_features(unleash_client):
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
     # Create Unleash client and check initial load
-    unleash_client.metrics_interval = 1
     unleash_client.initialize_client()
     time.sleep(1)
 
@@ -426,7 +425,7 @@ def test_uc_registers_metrics_for_nonexistent_features(unleash_client):
     unleash_client.is_enabled("nonexistent-flag")
 
     # Verify that the metrics are serialized
-    time.sleep(1)
+    time.sleep(12)
     request = json.loads(responses.calls[-1].request.body)
     assert request["bucket"]["toggles"]["nonexistent-flag"]["no"] == 1
 
@@ -441,7 +440,6 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
     # Create Unleash client and check initial load
-    unleash_client.metrics_interval = 1
     unleash_client.initialize_client()
     time.sleep(1)
 
@@ -449,7 +447,7 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     unleash_client.get_variant("nonexistent-flag")
 
     # Verify that the metrics are serialized
-    time.sleep(1)
+    time.sleep(12)
     request = json.loads(responses.calls[-1].request.body)
     assert request["bucket"]["toggles"]["nonexistent-flag"]["no"] == 1
     assert request["bucket"]["toggles"]["nonexistent-flag"]["variants"]["disabled"] == 1

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -271,6 +271,14 @@ def test_uc_fallbackfunction(unleash_client, mocker):
     assert unleash_client.is_enabled("testFlag", fallback_function=good_fallback)
     assert fallback_spy.call_count == 0
 
+def test_uc_tracks_metrics_even_when_not_initialized(unleash_client):
+    assert not unleash_client.is_enabled("testFlag")
+    assert unleash_client.features["testFlag"]["no"] == 1
+
+    unleash_client.get_variant("testFlag")
+    assert unleash_client.features["testFlag"]["no"] == 2
+    assert unleash_client.features["testFlag"]["variants"]["disabled"] == 1
+
 
 @responses.activate
 def test_uc_dirty_cache(unleash_client_nodestroy):

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -408,6 +408,7 @@ def test_uc_metrics(unleash_client):
     request = json.loads(responses.calls[-1].request.body)
     assert request["bucket"]["toggles"]["testFlag"]["yes"] == 1
 
+
 @responses.activate
 def test_uc_registers_metrics_for_nonexistent_features(unleash_client):
     # Set up API
@@ -451,6 +452,7 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     request = json.loads(responses.calls[-1].request.body)
     assert request["bucket"]["toggles"]["nonexistent-flag"]["no"] == 1
     assert request["bucket"]["toggles"]["nonexistent-flag"]["variants"]["disabled"] == 1
+
 
 @responses.activate
 def test_uc_disabled_registration(unleash_client_toggle_only):

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -271,14 +271,6 @@ def test_uc_fallbackfunction(unleash_client, mocker):
     assert unleash_client.is_enabled("testFlag", fallback_function=good_fallback)
     assert fallback_spy.call_count == 0
 
-def test_uc_tracks_metrics_even_when_not_initialized(unleash_client):
-    assert not unleash_client.is_enabled("testFlag")
-    assert unleash_client.features["testFlag"]["no"] == 1
-
-    unleash_client.get_variant("testFlag")
-    assert unleash_client.features["testFlag"]["no"] == 2
-    assert unleash_client.features["testFlag"]["variants"]["disabled"] == 1
-
 
 @responses.activate
 def test_uc_dirty_cache(unleash_client_nodestroy):


### PR DESCRIPTION
## Description

This PR is the follow-up to #253 and makes the client track metrics for features that don't exist.

It achieves this by modifying the Unleash client's `is_enabled` and `get_variant` methods:
Whenever they are called with a feature that doesn't exist, we create a new feature with that name, `enabled = False`, no strategies, and no variants. The feature gets added to the clients list of features, and is then queried for its state (to track metrics; we know it'll be false).

The tests ensure that metrics are sent for these nonexistent features, but does not care about the implementation, so we should be able to change that as much as we want later.

### Discussion point

I've been back and forth a couple of times regarding how best to track these features. Because the `send_metrics` function already takes care of everything related to sending and resetting metrics, it'd be nice to leave that as it is. As such, it'd be nice to track nonexistent features as part of the regular list of features. 

The current implementation uses a boolean field to indicate whether a feature exists only to track metrics or whether it should be evaluated properly. I considered using a subclass to tell them apart instead, but because the loader (`loader.py`) simply **updates** the objects instead of replacing them wholesale (probably to preserve metrics), then that caused some problems.

The current implementation *works*, but I'm not sure it's very pythonic or the best (or even a particularly good) solution, so I'd appreciate any input around that.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules