### PR TITLE
Constrain python-dateutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 * (Minor) Switch to ruff for linting and black for formatting.
+* (Minor) Constrain the version of `python-dateutil` appropriately to `>=2.8.1` to avoid an import error.  Thanks @felix-hilden!
 
 ## v5.6.0
 * (Major) Add support for event callbacks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies=[
     "mmhash3",
     "apscheduler < 4.0.0",
     "importlib_metadata",
-    "python-dateutil",
+    "python-dateutil >= 2.8.1",
     "semver < 3.0.0"
 ]
 


### PR DESCRIPTION
# Description

Constrain python-dateutil to avoid an import error, as discussed in #266.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
