### PR TITLE
Custom scheduler crashes if it's started before `UnleashClient.initialize_client`

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -261,7 +261,8 @@ class UnleashClient:
 
                 job_func(**job_args)  # type: ignore
                 # Start periodic jobs
-                self.unleash_scheduler.start()
+                if not self.unleash_scheduler.running:
+                    self.unleash_scheduler.start()
                 self.fl_job = self.unleash_scheduler.add_job(
                     job_func,
                     trigger=IntervalTrigger(


### PR DESCRIPTION
# Description

I have not create an issue, but I have a real issue with custom apscheduler, because UnleashClient tries to run it even though it's running already.

I applied those changes locally and it fixed the issue for me.

This will make https://github.com/Unleash/unleash-client-python/pull/223 more complete.

### For additional context
there's a thing that needs to rethinking and that is who is responsible for starting the scheduler - package or users code? Three cases:
- someone is using UnleashClient without any modification - apscheduler should start on `initialize_client` as it does now
- someone is using UnleashClient with custom scheduler and doesn't care when scheduler should be started up - `initialize_client` should start the scheduler for Unleash and users code
- someone wants to start the scheduler later - in this case unleash should never start the scheduler, but wait for the scheduler to be started; something like `start_scheduler: bool = True)` should be a part of `initialize_client` interface, allowing users to decide when scheduler should start. In this case, added jobs are kept in the jobstore so it's safe to start the scheduler later on. 

### Traceback 
My redacted traceback:
```
2023-08-23 15:28:34.000322 [ERROR] [PID:78855] [logger:jobs] jobs.exception_handler -: Unhandled error occurred. <class 'apscheduler.schedulers.SchedulerAlreadyRunningError'>: Scheduler is already running
Traceback (most recent call last):
  File "/Users/***/.local/share/virtualenvs/***/lib/python3.11/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/***/code/***-project/***-service/worker/jobs.py", line 84, in receive
    return _receive(session_id)
           ^^^^^^^^^^^^^^^^^^^^
  File "src/dependency_injector/_cwiring.pyx", line 28, in dependency_injector._cwiring._get_sync_patched._patched
  File "/Users/***/code/***-project/***-service/worker/jobs.py", line 101, in _receive
    rest_client.receive_message(session_id)
  File "src/dependency_injector/_cwiring.pyx", line 28, in dependency_injector._cwiring._get_sync_patched._patched
  File "/Users/***/code/***-project/***-service/worker/trigger.py", line 236, in receive_message
    manager = ***Manager()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/dependency_injector/_cwiring.pyx", line 26, in dependency_injector._cwiring._get_sync_patched._patched
  File "src/dependency_injector/providers.pyx", line 225, in dependency_injector.providers.Provider.__call__
  File "src/dependency_injector/providers.pyx", line 2689, in dependency_injector.providers.Factory._provide
  File "src/dependency_injector/providers.pxd", line 650, in dependency_injector.providers.__factory_call
  File "src/dependency_injector/providers.pxd", line 577, in dependency_injector.providers.__call
  File "src/dependency_injector/providers.pxd", line 445, in dependency_injector.providers.__provide_keyword_args
  File "src/dependency_injector/providers.pxd", line 365, in dependency_injector.providers.__get_value
  File "src/dependency_injector/providers.pyx", line 225, in dependency_injector.providers.Provider.__call__
  File "src/dependency_injector/providers.pyx", line 2689, in dependency_injector.providers.Factory._provide
  File "src/dependency_injector/providers.pxd", line 650, in dependency_injector.providers.__factory_call
  File "src/dependency_injector/providers.pxd", line 608, in dependency_injector.providers.__call
  File "/Users/***/code/***-project/***-service/worker/feature_flag.py", line 32, in __init__
    self.client.initialize_client()
  File "/Users/***/.local/share/virtualenvs/***/lib/python3.11/site-packages/UnleashClient/__init__.py", line 248, in initialize_client
    raise excep
  File "/Users/***/.local/share/virtualenvs/***/lib/python3.11/site-packages/UnleashClient/__init__.py", line 228, in initialize_client
    self.unleash_scheduler.start()
  File "/Users/***/.local/share/virtualenvs/***/lib/python3.11/site-packages/apscheduler/schedulers/asyncio.py", line 37, in start
    super(AsyncIOScheduler, self).start(paused)
  File "/Users/***/.local/share/virtualenvs/***/lib/python3.11/site-packages/apscheduler/schedulers/base.py", line 143, in start
    raise SchedulerAlreadyRunningError
apscheduler.schedulers.SchedulerAlreadyRunningError: Scheduler is already running
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
