### PR TITLE
fix: make check_date_operators work with dateutil < 2.8.1

### DIFF
--- a/UnleashClient/constraints/Constraint.py
+++ b/UnleashClient/constraints/Constraint.py
@@ -125,6 +125,7 @@ class Constraint:
 
         try:
             from dateutil.parser import ParserError
+
             DateUtilParserError = ParserError
         except:
             DateUtilParserError = ValueError

--- a/UnleashClient/constraints/Constraint.py
+++ b/UnleashClient/constraints/Constraint.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Optional, Union
 
 import semver
-from dateutil.parser import ParserError, parse
+from dateutil.parser import parse
 
 from UnleashClient.utils import LOGGER, get_identifier
 
@@ -124,12 +124,18 @@ class Constraint:
         parsing_exception = False
 
         try:
+            from dateutil.parser import ParserError
+            DateUtilParserError = ParserError
+        except:
+            DateUtilParserError = ValueError
+
+        try:
             parsed_date = parse(self.value)
             if isinstance(context_value, str):
                 context_date = parse(context_value)
             else:
                 context_date = context_value
-        except ParserError:
+        except DateUtilParserError:
             LOGGER.error(f"Unable to parse date: {self.value}")
             parsing_exception = True
 

--- a/UnleashClient/constraints/Constraint.py
+++ b/UnleashClient/constraints/Constraint.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-name, too-few-public-methods, use-a-generator
 from datetime import datetime
 from enum import Enum
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import semver
 from dateutil.parser import parse
@@ -123,11 +123,13 @@ class Constraint:
         return_value = False
         parsing_exception = False
 
+        DateUtilParserError: Any
+
         try:
             from dateutil.parser import ParserError
 
             DateUtilParserError = ParserError
-        except:
+        except ImportError:
             DateUtilParserError = ValueError
 
         try:

--- a/tests/unit_tests/test_features.py
+++ b/tests/unit_tests/test_features.py
@@ -88,7 +88,7 @@ def test_create_feature_exception(test_feature):
 
 def test_select_variation_novariation(test_feature):
     selected_variant = test_feature.get_variant()
-    assert type(selected_variant) == dict
+    assert isinstance(selected_variant, dict)
     assert selected_variant["name"] == "disabled"
 
 


### PR DESCRIPTION
# Description

For better discussion about https://github.com/Unleash/unleash-client-python/issues/266

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
