### PR TITLE
fix: update responses mock for etag test

### DIFF
--- a/tests/unit_tests/api/test_feature.py
+++ b/tests/unit_tests/api/test_feature.py
@@ -1,6 +1,3 @@
-from datetime import date
-
-import pytest
 import responses
 from pytest import mark, param
 
@@ -89,15 +86,9 @@ def test_get_feature_toggle_failed_etag():
     assert not etag
 
 
-@pytest.mark.skipif(
-    date.today() < date(2023, 10, 1),
-    reason="This is currently breaking due to a dependency or the test setup. Skipping this allows us to run tests in CI without this popping up as an error all the time.",
-)
 @responses.activate
 def test_get_feature_toggle_etag_present():
-    responses.add(
-        responses.GET, PROJECT_URL, json={}, status=304, headers={"etag": ETAG_VALUE}
-    )
+    responses.add(responses.GET, PROJECT_URL, status=304, headers={"etag": ETAG_VALUE})
 
     (result, etag) = get_feature_toggles(
         URL,


### PR DESCRIPTION
# Description

It was brought up in https://github.com/Unleash/unleash-client-python/issues/275 that a test was failing. The reason appears to be because the response was passing `{}` back in a 304 which requests doesn't like. This behavior is consistent with [RFC 7232 - 4.1 304 Not Modified](https://datatracker.ietf.org/doc/html/rfc7232#section-4.1) i.e. a 304 should not have a body. Another way to confirm this is the root cause is to note the exception

```
requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(2 bytes read, -2 more expected)', IncompleteRead(2 bytes read, -2 more expected))
```

points out it read two bytes (`{}`) but expected nothing.

Fixes https://github.com/Unleash/unleash-client-python/issues/275

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
