### PR TITLE
feat: configurable timeout and retries

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -249,8 +249,6 @@ class UnleashClient:
                 if fetch_toggles:
                     job_args = {
                         "url": self.unleash_url,
-                        "request_timeout": self.unleash_request_timeout,
-                        "request_retries": self.unleash_request_retries,
                         "app_name": self.unleash_app_name,
                         "instance_id": self.unleash_instance_id,
                         "custom_headers": self.unleash_custom_headers,
@@ -258,6 +256,8 @@ class UnleashClient:
                         "cache": self.cache,
                         "features": self.features,
                         "strategy_mapping": self.strategy_mapping,
+                        "request_timeout": self.unleash_request_timeout,
+                        "request_retries": self.unleash_request_retries,
                         "project": self.unleash_project_name,
                     }
                     job_func: Callable = fetch_and_load_features

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -13,7 +13,13 @@ from apscheduler.schedulers.base import BaseScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from UnleashClient.api import register_client
-from UnleashClient.constants import DISABLED_VARIATION, ETAG, METRIC_LAST_SENT_TIME, REQUEST_TIMEOUT, REQUEST_RETRIES
+from UnleashClient.constants import (
+    DISABLED_VARIATION,
+    ETAG,
+    METRIC_LAST_SENT_TIME,
+    REQUEST_RETRIES,
+    REQUEST_TIMEOUT,
+)
 from UnleashClient.events import UnleashEvent, UnleashEventType
 from UnleashClient.features import Feature
 from UnleashClient.loader import load_features
@@ -230,7 +236,7 @@ class UnleashClient:
                     "custom_options": self.unleash_custom_options,
                     "features": self.features,
                     "cache": self.cache,
-                    "request_timeout": self.unleash_request_timeout
+                    "request_timeout": self.unleash_request_timeout,
                 }
 
                 # Register app
@@ -243,7 +249,7 @@ class UnleashClient:
                         self.unleash_custom_headers,
                         self.unleash_custom_options,
                         self.strategy_mapping,
-                        self.unleash_request_timeout
+                        self.unleash_request_timeout,
                     )
 
                 if fetch_toggles:

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -4,7 +4,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-from UnleashClient.constants import FEATURES_URL, REQUEST_RETRIES, REQUEST_TIMEOUT
+from UnleashClient.constants import FEATURES_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 
 
@@ -15,10 +15,10 @@ def get_feature_toggles(
     instance_id: str,
     custom_headers: dict,
     custom_options: dict,
+    request_timeout: int,
+    request_retries: int,
     project: Optional[str] = None,
     cached_etag: str = "",
-    request_timeout: int = REQUEST_TIMEOUT,
-    request_retries: int = REQUEST_RETRIES,
 ) -> Tuple[dict, str]:
     """
     Retrieves feature flags from unleash central server.
@@ -32,6 +32,8 @@ def get_feature_toggles(
     :param instance_id:
     :param custom_headers:
     :param custom_options:
+    :param request_timeout:
+    :param request_retries:
     :param project:
     :param cached_etag:
     :return: (Feature flags, etag) if successful, ({},'') if not

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL, REQUEST_TIMEOUT
+from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 
 
@@ -12,7 +12,7 @@ def send_metrics(
     request_body: dict,
     custom_headers: dict,
     custom_options: dict,
-    request_timeout: int = REQUEST_TIMEOUT,
+    request_timeout: int,
 ) -> bool:
     """
     Attempts to send metrics to Unleash server
@@ -24,6 +24,7 @@ def send_metrics(
     :param request_body:
     :param custom_headers:
     :param custom_options:
+    :param request_timeout:
     :return: true if registration successful, false if registration unsuccessful or exception.
     """
     try:

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -7,7 +7,6 @@ from requests.exceptions import InvalidHeader, InvalidSchema, InvalidURL, Missin
 from UnleashClient.constants import (
     APPLICATION_HEADERS,
     REGISTER_URL,
-    REQUEST_TIMEOUT,
     SDK_NAME,
     SDK_VERSION,
 )
@@ -23,7 +22,7 @@ def register_client(
     custom_headers: dict,
     custom_options: dict,
     supported_strategies: dict,
-    request_timeout=REQUEST_TIMEOUT,
+    request_timeout: int,
 ) -> bool:
     """
     Attempts to register client with unleash server.
@@ -39,6 +38,7 @@ def register_client(
     :param custom_headers:
     :param custom_options:
     :param supported_strategies:
+    :param request_timeout:
     :return: true if registration successful, false if registration unsuccessful or exception.
     """
     registation_request = {

--- a/UnleashClient/periodic_tasks/fetch_and_load.py
+++ b/UnleashClient/periodic_tasks/fetch_and_load.py
@@ -9,8 +9,6 @@ from UnleashClient.utils import LOGGER
 
 def fetch_and_load_features(
     url: str,
-    request_timeout: int,
-    request_retries: int,
     app_name: str,
     instance_id: str,
     custom_headers: dict,
@@ -18,6 +16,8 @@ def fetch_and_load_features(
     cache: BaseCache,
     features: dict,
     strategy_mapping: dict,
+    request_timeout: int,
+    request_retries: int,
     project: Optional[str] = None,
 ) -> None:
     (feature_provisioning, etag) = get_feature_toggles(

--- a/UnleashClient/periodic_tasks/fetch_and_load.py
+++ b/UnleashClient/periodic_tasks/fetch_and_load.py
@@ -9,6 +9,8 @@ from UnleashClient.utils import LOGGER
 
 def fetch_and_load_features(
     url: str,
+    request_timeout: int,
+    request_retries: int,
     app_name: str,
     instance_id: str,
     custom_headers: dict,
@@ -24,6 +26,8 @@ def fetch_and_load_features(
         instance_id,
         custom_headers,
         custom_options,
+        request_timeout,
+        request_retries,
         project,
         cache.get(ETAG),
     )

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -15,6 +15,7 @@ def aggregate_and_send_metrics(
     custom_options: dict,
     features: dict,
     cache: BaseCache,
+    request_timeout: int
 ) -> None:
     feature_stats_list = []
 
@@ -44,7 +45,7 @@ def aggregate_and_send_metrics(
     }
 
     if feature_stats_list:
-        send_metrics(url, metrics_request, custom_headers, custom_options)
+        send_metrics(url, metrics_request, custom_headers, custom_options, request_timeout)
         cache.set(METRIC_LAST_SENT_TIME, datetime.now(timezone.utc))
     else:
         LOGGER.debug("No feature flags with metrics, skipping metrics submission.")

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -15,7 +15,7 @@ def aggregate_and_send_metrics(
     custom_options: dict,
     features: dict,
     cache: BaseCache,
-    request_timeout: int
+    request_timeout: int,
 ) -> None:
     feature_stats_list = []
 
@@ -45,7 +45,9 @@ def aggregate_and_send_metrics(
     }
 
     if feature_stats_list:
-        send_metrics(url, metrics_request, custom_headers, custom_options, request_timeout)
+        send_metrics(
+            url, metrics_request, custom_headers, custom_options, request_timeout
+        )
         cache.set(METRIC_LAST_SENT_TIME, datetime.now(timezone.utc))
     else:
         LOGGER.debug("No feature flags with metrics, skipping metrics submission.")

--- a/tests/unit_tests/api/test_feature.py
+++ b/tests/unit_tests/api/test_feature.py
@@ -14,6 +14,8 @@ from tests.utilities.testing_constants import (
     PROJECT_NAME,
     PROJECT_URL,
     URL,
+    REQUEST_TIMEOUT,
+    REQUEST_RETRIES
 )
 from UnleashClient.api import get_feature_toggles
 from UnleashClient.constants import FEATURES_URL
@@ -46,7 +48,7 @@ def test_get_feature_toggle(response, status, calls, expected):
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30, 3
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, REQUEST_RETRIES
     )
 
     assert len(responses.calls) == calls
@@ -64,7 +66,7 @@ def test_get_feature_toggle_project():
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30, 1, PROJECT_NAME
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, REQUEST_RETRIES, PROJECT_NAME
     )
 
     assert len(responses.calls) == 1
@@ -79,7 +81,7 @@ def test_get_feature_toggle_failed_etag():
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30, 3, PROJECT_NAME,
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, REQUEST_RETRIES, PROJECT_NAME,
     )
 
     assert len(responses.calls) == 4
@@ -96,8 +98,8 @@ def test_get_feature_toggle_etag_present():
         INSTANCE_ID,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
-        30,
-        1,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
         PROJECT_NAME,
         ETAG_VALUE,
     )
@@ -125,8 +127,8 @@ def test_get_feature_toggle_retries():
         INSTANCE_ID,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
-        30,
-        1,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
         PROJECT_NAME,
         ETAG_VALUE,
     )

--- a/tests/unit_tests/api/test_feature.py
+++ b/tests/unit_tests/api/test_feature.py
@@ -13,9 +13,9 @@ from tests.utilities.testing_constants import (
     INSTANCE_ID,
     PROJECT_NAME,
     PROJECT_URL,
-    URL,
+    REQUEST_RETRIES,
     REQUEST_TIMEOUT,
-    REQUEST_RETRIES
+    URL,
 )
 from UnleashClient.api import get_feature_toggles
 from UnleashClient.constants import FEATURES_URL
@@ -48,7 +48,13 @@ def test_get_feature_toggle(response, status, calls, expected):
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, REQUEST_RETRIES
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
     )
 
     assert len(responses.calls) == calls
@@ -66,7 +72,14 @@ def test_get_feature_toggle_project():
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, REQUEST_RETRIES, PROJECT_NAME
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
+        PROJECT_NAME,
     )
 
     assert len(responses.calls) == 1
@@ -81,7 +94,14 @@ def test_get_feature_toggle_failed_etag():
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, REQUEST_RETRIES, PROJECT_NAME,
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
+        PROJECT_NAME,
     )
 
     assert len(responses.calls) == 4

--- a/tests/unit_tests/api/test_feature.py
+++ b/tests/unit_tests/api/test_feature.py
@@ -46,7 +46,7 @@ def test_get_feature_toggle(response, status, calls, expected):
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30, 3
     )
 
     assert len(responses.calls) == calls
@@ -64,7 +64,7 @@ def test_get_feature_toggle_project():
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, PROJECT_NAME
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30, 1, PROJECT_NAME
     )
 
     assert len(responses.calls) == 1
@@ -79,7 +79,7 @@ def test_get_feature_toggle_failed_etag():
     )
 
     (result, etag) = get_feature_toggles(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, PROJECT_NAME
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30, 3, PROJECT_NAME,
     )
 
     assert len(responses.calls) == 4
@@ -96,6 +96,8 @@ def test_get_feature_toggle_etag_present():
         INSTANCE_ID,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
+        30,
+        1,
         PROJECT_NAME,
         ETAG_VALUE,
     )
@@ -123,6 +125,8 @@ def test_get_feature_toggle_retries():
         INSTANCE_ID,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
+        30,
+        1,
         PROJECT_NAME,
         ETAG_VALUE,
     )

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -3,7 +3,12 @@ from pytest import mark, param
 from requests import ConnectionError
 
 from tests.utilities.mocks.mock_metrics import MOCK_METRICS_REQUEST
-from tests.utilities.testing_constants import CUSTOM_HEADERS, CUSTOM_OPTIONS, URL, REQUEST_TIMEOUT
+from tests.utilities.testing_constants import (
+    CUSTOM_HEADERS,
+    CUSTOM_OPTIONS,
+    REQUEST_TIMEOUT,
+    URL,
+)
 from UnleashClient.api import send_metrics
 from UnleashClient.constants import METRICS_URL
 
@@ -27,7 +32,9 @@ FULL_METRICS_URL = URL + METRICS_URL
 def test_send_metrics(payload, status, expected):
     responses.add(responses.POST, FULL_METRICS_URL, **payload, status=status)
 
-    result = send_metrics(URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT)
+    result = send_metrics(
+        URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT
+    )
 
     assert len(responses.calls) == 1
     assert expected(result)

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -3,7 +3,7 @@ from pytest import mark, param
 from requests import ConnectionError
 
 from tests.utilities.mocks.mock_metrics import MOCK_METRICS_REQUEST
-from tests.utilities.testing_constants import CUSTOM_HEADERS, CUSTOM_OPTIONS, URL
+from tests.utilities.testing_constants import CUSTOM_HEADERS, CUSTOM_OPTIONS, URL, REQUEST_TIMEOUT
 from UnleashClient.api import send_metrics
 from UnleashClient.constants import METRICS_URL
 
@@ -27,7 +27,7 @@ FULL_METRICS_URL = URL + METRICS_URL
 def test_send_metrics(payload, status, expected):
     responses.add(responses.POST, FULL_METRICS_URL, **payload, status=status)
 
-    result = send_metrics(URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30)
+    result = send_metrics(URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT)
 
     assert len(responses.calls) == 1
     assert expected(result)

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -27,7 +27,7 @@ FULL_METRICS_URL = URL + METRICS_URL
 def test_send_metrics(payload, status, expected):
     responses.add(responses.POST, FULL_METRICS_URL, **payload, status=status)
 
-    result = send_metrics(URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS)
+    result = send_metrics(URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, 30)
 
     assert len(responses.calls) == 1
     assert expected(result)

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -42,6 +42,7 @@ def test_register_client(payload, status, expected):
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
         DEFAULT_STRATEGY_MAPPING,
+        30
     )
 
     assert len(responses.calls) == 1

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -9,8 +9,8 @@ from tests.utilities.testing_constants import (
     DEFAULT_STRATEGY_MAPPING,
     INSTANCE_ID,
     METRICS_INTERVAL,
+    REQUEST_TIMEOUT,
     URL,
-    REQUEST_TIMEOUT
 )
 from UnleashClient.api import register_client
 from UnleashClient.constants import REGISTER_URL
@@ -43,7 +43,7 @@ def test_register_client(payload, status, expected):
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
         DEFAULT_STRATEGY_MAPPING,
-        REQUEST_TIMEOUT
+        REQUEST_TIMEOUT,
     )
 
     assert len(responses.calls) == 1

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -10,6 +10,7 @@ from tests.utilities.testing_constants import (
     INSTANCE_ID,
     METRICS_INTERVAL,
     URL,
+    REQUEST_TIMEOUT
 )
 from UnleashClient.api import register_client
 from UnleashClient.constants import REGISTER_URL
@@ -42,7 +43,7 @@ def test_register_client(payload, status, expected):
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
         DEFAULT_STRATEGY_MAPPING,
-        30
+        REQUEST_TIMEOUT
     )
 
     assert len(responses.calls) == 1

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -11,6 +11,7 @@ from tests.utilities.testing_constants import (
     INSTANCE_ID,
     IP_LIST,
     URL,
+    REQUEST_TIMEOUT
 )
 from UnleashClient.cache import FileCache
 from UnleashClient.constants import METRIC_LAST_SENT_TIME, METRICS_URL
@@ -55,7 +56,7 @@ def test_aggregate_and_send_metrics():
     features = {"My Feature1": my_feature1, "My Feature 2": my_feature2}
 
     aggregate_and_send_metrics(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, 30
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, REQUEST_TIMEOUT
     )
 
     assert len(responses.calls) == 1
@@ -88,7 +89,7 @@ def test_no_metrics():
     features = {"My Feature1": my_feature1}
 
     aggregate_and_send_metrics(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, 30
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, REQUEST_TIMEOUT
     )
 
     assert len(responses.calls) == 0

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -10,8 +10,8 @@ from tests.utilities.testing_constants import (
     CUSTOM_OPTIONS,
     INSTANCE_ID,
     IP_LIST,
+    REQUEST_TIMEOUT,
     URL,
-    REQUEST_TIMEOUT
 )
 from UnleashClient.cache import FileCache
 from UnleashClient.constants import METRIC_LAST_SENT_TIME, METRICS_URL
@@ -56,7 +56,14 @@ def test_aggregate_and_send_metrics():
     features = {"My Feature1": my_feature1, "My Feature 2": my_feature2}
 
     aggregate_and_send_metrics(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, REQUEST_TIMEOUT
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        features,
+        cache,
+        REQUEST_TIMEOUT,
     )
 
     assert len(responses.calls) == 1
@@ -89,7 +96,14 @@ def test_no_metrics():
     features = {"My Feature1": my_feature1}
 
     aggregate_and_send_metrics(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, REQUEST_TIMEOUT
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        features,
+        cache,
+        REQUEST_TIMEOUT,
     )
 
     assert len(responses.calls) == 0

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -55,7 +55,7 @@ def test_aggregate_and_send_metrics():
     features = {"My Feature1": my_feature1, "My Feature 2": my_feature2}
 
     aggregate_and_send_metrics(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, 30
     )
 
     assert len(responses.calls) == 1
@@ -88,7 +88,7 @@ def test_no_metrics():
     features = {"My Feature1": my_feature1}
 
     aggregate_and_send_metrics(
-        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache
+        URL, APP_NAME, INSTANCE_ID, CUSTOM_HEADERS, CUSTOM_OPTIONS, features, cache, 30
     )
 
     assert len(responses.calls) == 0

--- a/tests/unit_tests/periodic/test_fetch_and_load.py
+++ b/tests/unit_tests/periodic/test_fetch_and_load.py
@@ -14,6 +14,8 @@ from tests.utilities.testing_constants import (
     PROJECT_NAME,
     PROJECT_URL,
     URL,
+    REQUEST_TIMEOUT,
+    REQUEST_RETRIES
 )
 from UnleashClient.constants import ETAG, FEATURES_URL
 from UnleashClient.features import Feature
@@ -37,8 +39,6 @@ def test_fetch_and_load(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
-        30,
-        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -46,6 +46,8 @@ def test_fetch_and_load(cache_empty):  # noqa: F811
         temp_cache,
         in_memory_features,
         DEFAULT_STRATEGY_MAPPING,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
     )
 
     assert isinstance(in_memory_features["testFlag"], Feature)
@@ -63,8 +65,6 @@ def test_fetch_and_load_project(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
-        30,
-        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -72,6 +72,8 @@ def test_fetch_and_load_project(cache_empty):  # noqa: F811
         temp_cache,
         in_memory_features,
         DEFAULT_STRATEGY_MAPPING,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
         PROJECT_NAME,
     )
 
@@ -90,8 +92,6 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
-        30,
-        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -99,6 +99,8 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
         temp_cache,
         in_memory_features,
         DEFAULT_STRATEGY_MAPPING,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
     )
 
     # Fail next request
@@ -107,8 +109,6 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
-        30,
-        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -116,6 +116,8 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
         temp_cache,
         in_memory_features,
         DEFAULT_STRATEGY_MAPPING,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
     )
 
     assert isinstance(in_memory_features["testFlag"], Feature)

--- a/tests/unit_tests/periodic/test_fetch_and_load.py
+++ b/tests/unit_tests/periodic/test_fetch_and_load.py
@@ -13,9 +13,9 @@ from tests.utilities.testing_constants import (
     INSTANCE_ID,
     PROJECT_NAME,
     PROJECT_URL,
-    URL,
+    REQUEST_RETRIES,
     REQUEST_TIMEOUT,
-    REQUEST_RETRIES
+    URL,
 )
 from UnleashClient.constants import ETAG, FEATURES_URL
 from UnleashClient.features import Feature

--- a/tests/unit_tests/periodic/test_fetch_and_load.py
+++ b/tests/unit_tests/periodic/test_fetch_and_load.py
@@ -37,6 +37,8 @@ def test_fetch_and_load(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
+        30,
+        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -61,6 +63,8 @@ def test_fetch_and_load_project(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
+        30,
+        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -86,6 +90,8 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
+        30,
+        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,
@@ -101,6 +107,8 @@ def test_fetch_and_load_failure(cache_empty):  # noqa: F811
 
     fetch_and_load_features(
         URL,
+        30,
+        1,
         APP_NAME,
         INSTANCE_ID,
         CUSTOM_HEADERS,

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -32,6 +32,8 @@ from tests.utilities.testing_constants import (
     REFRESH_INTERVAL,
     REFRESH_JITTER,
     URL,
+    REQUEST_TIMEOUT,
+    REQUEST_RETRIES
 )
 from UnleashClient import INSTANCES, UnleashClient
 from UnleashClient.cache import FileCache
@@ -160,6 +162,8 @@ def test_UC_initialize_full():
         DISABLE_REGISTRATION,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES
     )
     assert client.unleash_instance_id == INSTANCE_ID
     assert client.unleash_refresh_interval == REFRESH_INTERVAL

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -31,9 +31,9 @@ from tests.utilities.testing_constants import (
     PROJECT_URL,
     REFRESH_INTERVAL,
     REFRESH_JITTER,
-    URL,
+    REQUEST_RETRIES,
     REQUEST_TIMEOUT,
-    REQUEST_RETRIES
+    URL,
 )
 from UnleashClient import INSTANCES, UnleashClient
 from UnleashClient.cache import FileCache
@@ -163,7 +163,7 @@ def test_UC_initialize_full():
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
         REQUEST_TIMEOUT,
-        REQUEST_RETRIES
+        REQUEST_RETRIES,
     )
     assert client.unleash_instance_id == INSTANCE_ID
     assert client.unleash_refresh_interval == REFRESH_INTERVAL

--- a/tests/utilities/testing_constants.py
+++ b/tests/utilities/testing_constants.py
@@ -22,6 +22,8 @@ DISABLE_METRICS = True
 DISABLE_REGISTRATION = True
 CUSTOM_HEADERS = {"name": "My random header."}
 CUSTOM_OPTIONS = {"verify": False}
+REQUEST_TIMEOUT = 30
+REQUEST_RETRIES = 3
 
 # URLs
 URL = "http://localhost:4242/api"


### PR DESCRIPTION
# Description

Configurable request timeout and retry count. Added the new params at the end of all param lists before the default params (in all relevant methods).

I compared Python SDK config options to Node SDK and timeout is present in Node SDK. So adding it here should be a non-issue. Retry config is not available in Node but I see no harm in exposing it here.

Closes https://github.com/Unleash/unleash-client-python/issues/290

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
