### PR TITLE
Fix/double execution result

### DIFF
--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -2,7 +2,7 @@
 from typing import Dict, Optional, cast
 
 from UnleashClient.constants import DISABLED_VARIATION
-from UnleashClient.strategies import EvaluationResult, Strategy
+from UnleashClient.strategies import EvaluationResult
 from UnleashClient.utils import LOGGER
 from UnleashClient.variants import Variants
 
@@ -127,11 +127,11 @@ class Feature:
         if self.enabled:
             try:
                 if self.strategies:
-                    enabled_strategy: Strategy = next(
-                        (x for x in self.strategies if x.execute(context)), None
-                    )
-                    if enabled_strategy is not None:
-                        strategy_result = enabled_strategy.get_result(context)
+                    for strategy in self.strategies:
+                        r = strategy.get_result(context)
+                        if r.enabled:
+                            strategy_result = r
+                            break
 
                 else:
                     # If no strategies are present, should default to true. This isn't possible via UI.


### PR DESCRIPTION
Duplicate of #288 

I only added a test to verify that the counts stay within the bounds and confirmed that the old version were consistently distributing unevenly.

# Description

This commit https://github.com/Unleash/unleash-client-python/commit/0e7b894851c5a9bec69e9926fcc07a87250fb958 introduced a new method: `Feature._get_evaluation_result(context) -> EvaluationResult`.
This method is used for instance to determine whether a feature is enabled or not. 
If there are strategies associated to the feature, this method makes a call to `strategy.execute(context)` and another to `enabled_strategy.get_result(context)` that itself calls `self.execute(context)`.
In the end, `Strategy.execute()` is called two times which is an issue in the case of a `GradualRolloutRandom` because a new random integer is compared each time to the rollout percentage.

Steps to follow to highlight the issue:
- create a feature with a gradual rollout and a random stickiness (e.g. https://app.unleash-hosted.com/demo/projects/test-random-stickiness/features/f-random-stickiness)
- set the rollout percentage to 50%
- execute the following script:
```
from UnleashClient import UnleashClient

api_token = "..."
client = UnleashClient(
    url="https://app.unleash-hosted.com/demo/api/",
    app_name="my_python_app",
    custom_headers={"Authorization": api_token}
)
client.initialize_client()

total_enabled = sum(client.is_enabled("f-random-stickiness") for i in range(1000))

print(total_enabled)  # 228
```

The change in this pull request proposes to remove the double call to `Strategy.execute()`.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests  (manual test with the above snippet)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Co-authored-by: @ClementDelgrange
