### PR TITLE
WIP: Obey HTTP status codes from upstream.

### DIFF
--- a/UnleashClient/api/backoff.py
+++ b/UnleashClient/api/backoff.py
@@ -1,0 +1,49 @@
+from UnleashClient.utils import LOGGER
+
+
+class BackoffStrategy:
+    def __init__(self):
+        self.failures = 0
+        self.skips = 0
+        self.max_skips = 10
+        self.normal_interval_seconds = 5
+        self.longest_acceptable_interval_seconds = 60 * 60 * 24 * 7  # 1 week
+        self.initialized = (
+            False  # Consider not initialized until we have a successful call to the API
+        )
+
+    def handle_response(self, url: str, status_code: int):
+        if self.initialized and status_code in [401, 403, 404]:
+            self.skips = self.max_skips
+            self.failures += 1
+            LOGGER.error(
+                f"Server said that the endpoint at {url} does not exist. Backing off to {self.skips} times our poll interval (of {self.normal_interval_seconds} seconds) to avoid overloading server"
+                if status_code == 404
+                else f"Client was not authorized to talk to the Unleash API at {url}. Backing off to {self.skips} times our poll interval (of {self.normal_interval_seconds} seconds) to avoid overloading server"
+            )
+
+        elif self.initialized and status_code == 429:
+            self.failures += 1
+            self.skips = min(self.max_skips, self.failures)
+            LOGGER.info(
+                f"RATE LIMITED for the {self.failures} time. Further backing off. Current backoff at {self.skips} times our interval (of {self.normal_interval_seconds} seconds)"
+            )
+        elif self.initialized and status_code > 500:
+            self.failures += 1
+            self.skips = min(self.max_skips, self.failures)
+            LOGGER.info(
+                f"Server failed with a {status_code} status code. Backing off. Current backoff at {self.skips} times our poll interval (of {self.normal_interval_seconds} seconds)"
+            )
+
+        else:
+            # successful response
+            self.initialized = True
+            if self.failures > 0:
+                self.failures -= 1
+                self.skips = max(0, self.failures)
+
+    def performAction(self):
+        return self.skips <= 0
+
+    def skipped(self):
+        self.skips -= 1

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -42,7 +42,9 @@ def get_feature_toggles(
     :return: (Feature flags, etag) if successful, ({},'') if not
     """
     try:
-        backoff_strategy = backoff_strategy or BackoffStrategy() # TODO creating it here doesn't make sense
+        backoff_strategy = (
+            backoff_strategy or BackoffStrategy()
+        )  # TODO creating it here doesn't make sense
         if not backoff_strategy.performAction():
             backoff_strategy.skipped()
             return {}, ""

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -1,8 +1,8 @@
 import json
 
 import requests
-from UnleashClient.api.backoff import BackoffStrategy
 
+from UnleashClient.api.backoff import BackoffStrategy
 from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -1,6 +1,7 @@
 import json
 
 import requests
+from UnleashClient.api.backoff import BackoffStrategy
 
 from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL
 from UnleashClient.utils import LOGGER, log_resp_info
@@ -13,6 +14,7 @@ def send_metrics(
     custom_headers: dict,
     custom_options: dict,
     request_timeout: int,
+    backoff_strategy: BackoffStrategy,
 ) -> bool:
     """
     Attempts to send metrics to Unleash server
@@ -39,6 +41,7 @@ def send_metrics(
             **custom_options,
         )
 
+        backoff_strategy.handle_response(url + METRICS_URL, resp.status_code)
         if resp.status_code != 202:
             log_resp_info(resp)
             LOGGER.warning("Unleash CLient metrics submission failed.")

--- a/UnleashClient/periodic_tasks/fetch_and_load.py
+++ b/UnleashClient/periodic_tasks/fetch_and_load.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from UnleashClient.api import get_feature_toggles
+from UnleashClient.api.backoff import BackoffStrategy
 from UnleashClient.cache import BaseCache
 from UnleashClient.constants import ETAG, FEATURES_URL
 from UnleashClient.loader import load_features
@@ -19,6 +20,7 @@ def fetch_and_load_features(
     request_timeout: int,
     request_retries: int,
     project: Optional[str] = None,
+    backoff_strategy: Optional[BackoffStrategy] = BackoffStrategy(),
 ) -> None:
     (feature_provisioning, etag) = get_feature_toggles(
         url,
@@ -30,6 +32,7 @@ def fetch_and_load_features(
         request_retries,
         project,
         cache.get(ETAG),
+        backoff_strategy,
     )
 
     if feature_provisioning:

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -21,11 +21,13 @@ def aggregate_and_send_metrics(
     backoff_strategy: Optional[BackoffStrategy] = None,
 ) -> None:
     feature_stats_list = []
-    backoff_strategy = backoff_strategy or BackoffStrategy() # TODO creating it here doesn't make sense
+    backoff_strategy = (
+        backoff_strategy or BackoffStrategy()
+    )  # TODO creating it here doesn't make sense
     if not backoff_strategy.performAction():
         backoff_strategy.skipped()
         return {}, ""
-    
+
     for feature_name in features.keys():
         if not (features[feature_name].yes_count or features[feature_name].no_count):
             continue
@@ -53,7 +55,12 @@ def aggregate_and_send_metrics(
 
     if feature_stats_list:
         send_metrics(
-            url, metrics_request, custom_headers, custom_options, request_timeout, backoff_strategy
+            url,
+            metrics_request,
+            custom_headers,
+            custom_options,
+            request_timeout,
+            backoff_strategy,
         )
         # TODO should we do if send_metrics then update cache? We're also updating in the case of an exception
         cache.set(METRIC_LAST_SENT_TIME, datetime.now(timezone.utc))

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -1,7 +1,9 @@
 from collections import ChainMap
 from datetime import datetime, timezone
+from typing import Optional
 
 from UnleashClient.api import send_metrics
+from UnleashClient.api.backoff import BackoffStrategy
 from UnleashClient.cache import BaseCache
 from UnleashClient.constants import METRIC_LAST_SENT_TIME
 from UnleashClient.utils import LOGGER
@@ -16,9 +18,14 @@ def aggregate_and_send_metrics(
     features: dict,
     cache: BaseCache,
     request_timeout: int,
+    backoff_strategy: Optional[BackoffStrategy] = None,
 ) -> None:
     feature_stats_list = []
-
+    backoff_strategy = backoff_strategy or BackoffStrategy() # TODO creating it here doesn't make sense
+    if not backoff_strategy.performAction():
+        backoff_strategy.skipped()
+        return {}, ""
+    
     for feature_name in features.keys():
         if not (features[feature_name].yes_count or features[feature_name].no_count):
             continue
@@ -46,8 +53,9 @@ def aggregate_and_send_metrics(
 
     if feature_stats_list:
         send_metrics(
-            url, metrics_request, custom_headers, custom_options, request_timeout
+            url, metrics_request, custom_headers, custom_options, request_timeout, backoff_strategy
         )
+        # TODO should we do if send_metrics then update cache? We're also updating in the case of an exception
         cache.set(METRIC_LAST_SENT_TIME, datetime.now(timezone.utc))
     else:
         LOGGER.debug("No feature flags with metrics, skipping metrics submission.")

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -1,6 +1,7 @@
 import responses
 from pytest import mark, param
 from requests import ConnectionError
+from UnleashClient.api.backoff import BackoffStrategy
 
 from tests.utilities.mocks.mock_metrics import MOCK_METRICS_REQUEST
 from tests.utilities.testing_constants import (
@@ -33,7 +34,7 @@ def test_send_metrics(payload, status, expected):
     responses.add(responses.POST, FULL_METRICS_URL, **payload, status=status)
 
     result = send_metrics(
-        URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT
+        URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, BackoffStrategy()
     )
 
     assert len(responses.calls) == 1

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -1,7 +1,6 @@
 import responses
 from pytest import mark, param
 from requests import ConnectionError
-from UnleashClient.api.backoff import BackoffStrategy
 
 from tests.utilities.mocks.mock_metrics import MOCK_METRICS_REQUEST
 from tests.utilities.testing_constants import (
@@ -11,6 +10,7 @@ from tests.utilities.testing_constants import (
     URL,
 )
 from UnleashClient.api import send_metrics
+from UnleashClient.api.backoff import BackoffStrategy
 from UnleashClient.constants import METRICS_URL
 
 FULL_METRICS_URL = URL + METRICS_URL
@@ -34,7 +34,12 @@ def test_send_metrics(payload, status, expected):
     responses.add(responses.POST, FULL_METRICS_URL, **payload, status=status)
 
     result = send_metrics(
-        URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT, BackoffStrategy()
+        URL,
+        MOCK_METRICS_REQUEST,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        BackoffStrategy(),
     )
 
     assert len(responses.calls) == 1


### PR DESCRIPTION
# Description

Previously we have treated any status code as equal. This PR changes that to allow 429 and 50x status codes to incrementally increase the interval between each time we call. And then gradually decrease once it starts succeeding.

This is a port of https://github.com/Unleash/unleash-client-java/pull/221 into the Python SDK

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
