### PR TITLE
fix: don't count stats for parent flags, even in get_variant

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install packages
         run: |
           make install
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.8"
       - name: Install packages
         run: |
           make install
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/UnleashClient/features/Feature.py
+++ b/UnleashClient/features/Feature.py
@@ -101,7 +101,7 @@ class Feature:
         :param context: Context information
         :return:
         """
-        evaluation_result = self._get_evaluation_result(context)
+        evaluation_result = self._get_evaluation_result(context, skip_stats)
         is_feature_enabled = evaluation_result.enabled
         variant = evaluation_result.variant
         if variant is None or (is_feature_enabled and variant == DISABLED_VARIATION):

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -538,6 +538,29 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     # Set up API
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
     responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    # Create Unleash client and check initial load
+    unleash_client.initialize_client()
+    time.sleep(1)
+
+    # Check a flag that doesn't exist
+    unleash_client.get_variant("nonexistent-flag")
+
+    # Verify that the metrics are serialized
+    time.sleep(12)
+    request = json.loads(responses.calls[-1].request.body)
+    assert request["bucket"]["toggles"]["nonexistent-flag"]["no"] == 1
+    assert request["bucket"]["toggles"]["nonexistent-flag"]["variants"]["disabled"] == 1
+
+
+@responses.activate
+def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
         responses.GET,
         URL + FEATURES_URL,
         json=MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES,
@@ -559,30 +582,7 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     assert request["bucket"]["toggles"]["Child"]["yes"] == 2
     assert request["bucket"]["toggles"]["Child"]["variants"]["child-variant"] == 1
     assert request["bucket"]["toggles"]["Parent"]["yes"] == 0
-    assert request["bucket"]["toggles"]["Parent"]["variants"]["parent-variant"] == 0
-
-
-@responses.activate
-def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
-    # Set up API
-    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
-    responses.add(
-        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
-    )
-    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
-
-    # Create Unleash client and check initial load
-    unleash_client.initialize_client()
-    time.sleep(1)
-
-    # Check a flag that doesn't exist
-    unleash_client.get_variant("nonexistent-flag")
-
-    # Verify that the metrics are serialized
-    time.sleep(12)
-    request = json.loads(responses.calls[-1].request.body)
-    assert request["bucket"]["toggles"]["nonexistent-flag"]["no"] == 1
-    assert request["bucket"]["toggles"]["nonexistent-flag"]["variants"]["disabled"] == 1
+    assert len(request["bucket"]["toggles"]["Parent"]["variants"]) == 0
 
 
 @responses.activate

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -581,7 +581,7 @@ def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
     request = json.loads(responses.calls[-1].request.body)
     assert request["bucket"]["toggles"]["Child"]["yes"] == 2
     assert request["bucket"]["toggles"]["Child"]["variants"]["child-variant"] == 1
-    assert not "Parent" in request["bucket"]["toggles"]
+    assert "Parent" not in request["bucket"]["toggles"]
 
 
 @responses.activate

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -581,8 +581,7 @@ def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
     request = json.loads(responses.calls[-1].request.body)
     assert request["bucket"]["toggles"]["Child"]["yes"] == 2
     assert request["bucket"]["toggles"]["Child"]["variants"]["child-variant"] == 1
-    assert request["bucket"]["toggles"]["Parent"]["yes"] == 0
-    assert len(request["bucket"]["toggles"]["Parent"]["variants"]) == 0
+    assert not "Parent" in request["bucket"]["toggles"]
 
 
 @responses.activate

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -15,6 +15,7 @@ from tests.utilities.mocks.mock_features import (
     MOCK_FEATURE_RESPONSE,
     MOCK_FEATURE_RESPONSE_PROJECT,
     MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE,
+    MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES,
 )
 from tests.utilities.testing_constants import (
     APP_NAME,
@@ -534,6 +535,31 @@ def test_uc_metrics_dependencies(unleash_client):
 
 @responses.activate
 def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    # Create Unleash client and check initial load
+    unleash_client.initialize_client()
+    time.sleep(1)
+
+    # Check a flag that depends on a parent
+    unleash_client.is_enabled("Child")
+    unleash_client.get_variant("Child")
+
+    # Verify that the parent doesn't have any metrics registered
+    time.sleep(12)
+    request = json.loads(responses.calls[-1].request.body)
+    assert request["bucket"]["toggles"]["Child"]["yes"] == 2
+    assert request["bucket"]["toggles"]["Child"]["variants"]["child-variant"] == 1
+    assert request["bucket"]["toggles"]["Parent"]["yes"] == 0
+    assert request["bucket"]["toggles"]["Parent"]["variants"]["parent-variant"] == 0
+
+@responses.activate
+def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
     # Set up API
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
     responses.add(

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -15,7 +15,6 @@ from tests.utilities.mocks.mock_features import (
     MOCK_FEATURE_RESPONSE,
     MOCK_FEATURE_RESPONSE_PROJECT,
     MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE,
-    MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES,
 )
 from tests.utilities.testing_constants import (
     APP_NAME,
@@ -563,7 +562,7 @@ def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
     responses.add(
         responses.GET,
         URL + FEATURES_URL,
-        json=MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES,
+        json=MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE,
         status=200,
     )
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
@@ -572,15 +571,16 @@ def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):
     unleash_client.initialize_client()
     time.sleep(1)
 
+    child = "ChildWithVariant"
     # Check a flag that depends on a parent
-    unleash_client.is_enabled("Child")
-    unleash_client.get_variant("Child")
+    unleash_client.is_enabled(child)
+    unleash_client.get_variant(child)
 
     # Verify that the parent doesn't have any metrics registered
     time.sleep(12)
     request = json.loads(responses.calls[-1].request.body)
-    assert request["bucket"]["toggles"]["Child"]["yes"] == 2
-    assert request["bucket"]["toggles"]["Child"]["variants"]["child-variant"] == 1
+    assert request["bucket"]["toggles"][child]["yes"] == 2
+    assert request["bucket"]["toggles"][child]["variants"]["childVariant"] == 1
     assert "Parent" not in request["bucket"]["toggles"]
 
 

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -538,7 +538,10 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     # Set up API
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
     responses.add(
-        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES, status=200
+        responses.GET,
+        URL + FEATURES_URL,
+        json=MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES,
+        status=200,
     )
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
@@ -557,6 +560,7 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(unleash_client):
     assert request["bucket"]["toggles"]["Child"]["variants"]["child-variant"] == 1
     assert request["bucket"]["toggles"]["Parent"]["yes"] == 0
     assert request["bucket"]["toggles"]["Parent"]["variants"]["parent-variant"] == 0
+
 
 @responses.activate
 def test_uc_doesnt_count_metrics_for_dependency_parents(unleash_client):

--- a/tests/utilities/mocks/mock_features.py
+++ b/tests/utilities/mocks/mock_features.py
@@ -200,16 +200,20 @@ MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE = {
             "name": "ChildWithVariant",
             "description": "Feature toggle with variant that depends on Parent feature toggle",
             "enabled": True,
-            "strategies": [{"name": "default", "parameters": {},
-                            "variants": [
-                                {
-                                    "name": "childVariant",
-                                    "weight": 1000,
-                                    "stickiness": "default",
-                                    "weightType": "variable",
-                                }
-                            ],
-                            }],
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {},
+                    "variants": [
+                        {
+                            "name": "childVariant",
+                            "weight": 1000,
+                            "stickiness": "default",
+                            "weightType": "variable",
+                        }
+                    ],
+                }
+            ],
             "createdAt": "2018-10-09T06:04:05.667Z",
             "impressionData": False,
             "dependencies": [

--- a/tests/utilities/mocks/mock_features.py
+++ b/tests/utilities/mocks/mock_features.py
@@ -300,7 +300,11 @@ MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES = {
             "name": "Child",
             "description": "Feature toggle that depends on Parent feature toggle",
             "enabled": True,
-            "strategies": [{"name": "default", "parameters": {}, "variants": [
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {},
+                    "variants": [
                         {
                             "name": "child-variant",
                             "weight": 1000,
@@ -308,7 +312,8 @@ MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES = {
                             "weightType": "variable",
                         }
                     ],
-}],
+                }
+            ],
             "createdAt": "2018-10-09T06:04:05.667Z",
             "impressionData": False,
             "dependencies": [

--- a/tests/utilities/mocks/mock_features.py
+++ b/tests/utilities/mocks/mock_features.py
@@ -198,7 +198,7 @@ MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE = {
         },
         {
             "name": "ChildWithVariant",
-            "description": "Feature toggle with variant that depends on Parent feature toggle",
+            "description": "Feature toggle with variant that depends on a specific variant of the Parent feature toggle",
             "enabled": True,
             "strategies": [
                 {

--- a/tests/utilities/mocks/mock_features.py
+++ b/tests/utilities/mocks/mock_features.py
@@ -271,3 +271,52 @@ MOCK_FEATURE_ENABLED_NO_VARIANTS_RESPONSE = {
         },
     ],
 }
+
+MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES = {
+    "version": 1,
+    "features": [
+        {
+            "name": "Parent",
+            "description": "Dependency of Child feature toggle",
+            "enabled": True,
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {},
+                    "variants": [
+                        {
+                            "name": "parent-variant",
+                            "weight": 1000,
+                            "stickiness": "default",
+                            "weightType": "variable",
+                        }
+                    ],
+                }
+            ],
+            "createdAt": "2018-10-09T06:04:05.667Z",
+            "impressionData": False,
+        },
+        {
+            "name": "Child",
+            "description": "Feature toggle that depends on Parent feature toggle",
+            "enabled": True,
+            "strategies": [{"name": "default", "parameters": {}, "variants": [
+                        {
+                            "name": "child-variant",
+                            "weight": 1000,
+                            "stickiness": "default",
+                            "weightType": "variable",
+                        }
+                    ],
+}],
+            "createdAt": "2018-10-09T06:04:05.667Z",
+            "impressionData": False,
+            "dependencies": [
+                {
+                    "feature": "Parent",
+                    "variants": ["parent-variant"],
+                }
+            ],
+        },
+    ],
+}

--- a/tests/utilities/mocks/mock_features.py
+++ b/tests/utilities/mocks/mock_features.py
@@ -197,6 +197,29 @@ MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE = {
             ],
         },
         {
+            "name": "ChildWithVariant",
+            "description": "Feature toggle with variant that depends on Parent feature toggle",
+            "enabled": True,
+            "strategies": [{"name": "default", "parameters": {},
+                            "variants": [
+                                {
+                                    "name": "childVariant",
+                                    "weight": 1000,
+                                    "stickiness": "default",
+                                    "weightType": "variable",
+                                }
+                            ],
+                            }],
+            "createdAt": "2018-10-09T06:04:05.667Z",
+            "impressionData": False,
+            "dependencies": [
+                {
+                    "feature": "Parent",
+                    "variants": ["variant1"],
+                }
+            ],
+        },
+        {
             "name": "Disabled",
             "description": "Disabled feature toggle",
             "enabled": False,
@@ -268,60 +291,6 @@ MOCK_FEATURE_ENABLED_NO_VARIANTS_RESPONSE = {
             ],
             "createdAt": "2018-10-09T06:04:05.667Z",
             "impressionData": False,
-        },
-    ],
-}
-
-MOCK_FEATURE_WITH_VARIANT_DEPENDENCIES = {
-    "version": 1,
-    "features": [
-        {
-            "name": "Parent",
-            "description": "Dependency of Child feature toggle",
-            "enabled": True,
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {},
-                    "variants": [
-                        {
-                            "name": "parent-variant",
-                            "weight": 1000,
-                            "stickiness": "default",
-                            "weightType": "variable",
-                        }
-                    ],
-                }
-            ],
-            "createdAt": "2018-10-09T06:04:05.667Z",
-            "impressionData": False,
-        },
-        {
-            "name": "Child",
-            "description": "Feature toggle that depends on Parent feature toggle",
-            "enabled": True,
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {},
-                    "variants": [
-                        {
-                            "name": "child-variant",
-                            "weight": 1000,
-                            "stickiness": "default",
-                            "weightType": "variable",
-                        }
-                    ],
-                }
-            ],
-            "createdAt": "2018-10-09T06:04:05.667Z",
-            "impressionData": False,
-            "dependencies": [
-                {
-                    "feature": "Parent",
-                    "variants": ["parent-variant"],
-                }
-            ],
         },
     ],
 }


### PR DESCRIPTION
# Description

This PR fixes an issue where parent flags would have metrics counted when you call `get_variant` on a child flag. This was due to a missing `skip_stats` argument in the `get_variant` method of a feature.

I have added a test and the specific data setup that was reported to cause the issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules