### PR TITLE
meta: update pyproject.toml settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ addopts= """
 log_file_level="INFO"
 
 [tool.ruff]
-select = [
+lint.select = [
     "E",   # pycodestyle, error
     "W",   # pycodestyle, warning
     "F",   # pyflakes
@@ -68,11 +68,12 @@ select = [
     "YTT", # flake8-2020
     "I"    # isort
 ]
-ignore = ["E501", "PLR2004"]
 
-fixable = ["I"]
+lint.ignore = ["E501", "PLR2004"]
 
-[tool.ruff.pylint]
+lint.fixable = ["I"]
+
+[tool.ruff.lint.pylint]
 max-args = 25
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,8 @@ addopts= """
 """
 log_file_level="INFO"
 
-[tool.ruff]
-lint.select = [
+[tool.ruff.lint]
+select = [
     "E",   # pycodestyle, error
     "W",   # pycodestyle, warning
     "F",   # pyflakes
@@ -69,9 +69,9 @@ lint.select = [
     "I"    # isort
 ]
 
-lint.ignore = ["E501", "PLR2004"]
+ignore = ["E501", "PLR2004"]
 
-lint.fixable = ["I"]
+fixable = ["I"]
 
 [tool.ruff.lint.pylint]
 max-args = 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ select = [
     "YTT", # flake8-2020
     "I"    # isort
 ]
-
 ignore = ["E501", "PLR2004"]
 
 fixable = ["I"]


### PR DESCRIPTION
Based on this warning from CI:

```
 warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'fixable' -> 'lint.fixable'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'pylint' -> 'lint.pylint'
```

## Type of change

Please delete options that are not relevant.

- [x] Project file update