### PR TITLE
chore: adapt ruff call in build to new format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ fmt:
 
 lint:
 	black . --check && \
-	ruff UnleashClient tests docs && \
+	ruff check UnleashClient tests docs && \
 	mypy ${PROJECT_NAME} --install-types --non-interactive;
 
 pytest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ addopts= """
 log_file_level="INFO"
 
 [tool.ruff]
-select = [
+lint.select = [
     "E",   # pycodestyle, error
     "W",   # pycodestyle, warning
     "F",   # pyflakes
@@ -69,11 +69,11 @@ select = [
     "YTT", # flake8-2020
     "I"    # isort
 ]
-ignore = ["E501", "PLR2004"]
+lint.ignore = ["E501", "PLR2004"]
 
-fixable = ["I"]
+lint.fixable = ["I"]
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 25
 
 [tool.setuptools]

--- a/tests/unit_tests/test_custom_strategy.py
+++ b/tests/unit_tests/test_custom_strategy.py
@@ -66,7 +66,7 @@ def test_uc_customstrategy_happypath(recwarn):
 
     # Check warning on deprecated strategy.
     assert len(recwarn) >= 1
-    assert any([x.category == DeprecationWarning for x in recwarn])
+    assert any([x.category is DeprecationWarning for x in recwarn])
 
 
 @responses.activate


### PR DESCRIPTION
# Description

Ruff got an upgrade, the old `ruff <path>` command we use in the build no longer works. Now apparently it wants `ruff check <path>`

This new version of Ruff also raises a new lint, which is fixed in this PR.

Bonus points for fixing Ruff config in pyproject.toml that had been raising some warnings for some time

Fixes # (issue)

The build

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)\

# How Has This Been Tested?

This PR + build pipeline