### PR TITLE
chore: fix docs build

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -24,8 +24,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.pypi_password }}
       - name: Build docs
         run: |
-          cd docs
           make install-docs
+          cd docs
           make html
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
`install-docs` lives in the root makefile, not in the docs makefile