### PR TITLE
Safely handle datetime constraint values with and without timezone info

### DIFF
--- a/tests/unit_tests/test_constraints.py
+++ b/tests/unit_tests/test_constraints.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 import pytz
@@ -183,15 +183,61 @@ def test_constraints_DATE_BEFORE():
     assert constraint.apply({"currentTime": datetime(2022, 1, 21, tzinfo=pytz.UTC)})
 
 
-def test_constraints_default():
-    constraint = Constraint(constraint_dict=mock_constraints.CONSTRAINT_DATE_BEFORE)
+def test_constraints_DATE_AFTER_default():
+    constraint = Constraint(
+        constraint_dict={
+            **mock_constraints.CONSTRAINT_DATE_AFTER,
+            "value": (datetime.now(pytz.UTC) - timedelta(days=1)).isoformat(),
+        }
+    )
+
+    assert constraint.apply({})
+
+    constraint = Constraint(
+        constraint_dict={
+            **mock_constraints.CONSTRAINT_DATE_AFTER,
+            "value": (datetime.now(pytz.UTC) + timedelta(days=1)).isoformat(),
+        }
+    )
 
     assert not constraint.apply({})
 
 
+def test_constraints_DATE_BEFORE_default():
+    constraint = Constraint(
+        constraint_dict={
+            **mock_constraints.CONSTRAINT_DATE_BEFORE,
+            "value": (datetime.now(pytz.UTC) + timedelta(days=1)).isoformat(),
+        }
+    )
+
+    assert constraint.apply({})
+
+    constraint = Constraint(
+        constraint_dict={
+            **mock_constraints.CONSTRAINT_DATE_BEFORE,
+            "value": (datetime.now(pytz.UTC) - timedelta(days=1)).isoformat(),
+        }
+    )
+
+    assert not constraint.apply({})
+
+
+def test_constraints_tz_naive():
+    constraint = Constraint(constraint_dict=mock_constraints.CONSTRAINT_DATE_TZ_NAIVE)
+
+    assert constraint.apply(
+        {"currentTime": datetime(2022, 1, 22, 0, 10, tzinfo=pytz.UTC)}
+    )
+    assert not constraint.apply({"currentTime": datetime(2022, 1, 22, tzinfo=pytz.UTC)})
+    assert not constraint.apply(
+        {"currentTime": datetime(2022, 1, 21, 23, 50, tzinfo=pytz.UTC)}
+    )
+
+
 def test_constraints_date_error():
     constraint = Constraint(constraint_dict=mock_constraints.CONSTRAINT_DATE_ERROR)
-    assert not constraint.apply({"currentTime": datetime(2022, 1, 23)})
+    assert not constraint.apply({"currentTime": datetime(2022, 1, 23, tzinfo=pytz.UTC)})
 
 
 def test_constraints_SEMVER_EQ():

--- a/tests/utilities/mocks/mock_constraints.py
+++ b/tests/utilities/mocks/mock_constraints.py
@@ -153,6 +153,13 @@ CONSTRAINT_DATE_ERROR = {
     "inverted": False,
 }
 
+CONSTRAINT_DATE_TZ_NAIVE = {
+    "contextName": "currentTime",
+    "operator": "DATE_AFTER",
+    "value": "2022-01-22T00:00:00.000",
+    "inverted": False,
+}
+
 
 CONSTRAINT_SEMVER_EQ = {
     "contextName": "customField",


### PR DESCRIPTION
# Description

The Unleash web app provided timezone info when creating date constraints so this PR updates the client to also provide timezone info for datetime objects it creates. And then gracefully fall back to UTC if an ISO string is received with no timezone info. 

Fixes #323

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
