### PR TITLE
chore: drop support for python3.7, support python3.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT=3.7
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster
+ARG VARIANT=3.8
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
@@ -21,8 +21,8 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
 ENV PYENV_ROOT="/home/vscode/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
-RUN pyenv install 3.7 3.8 3.9 3.10 3.11 3.12
-RUN pyenv local 3.7 3.8 3.9 3.10 3.11 3.12
+RUN pyenv install 3.8 3.9 3.10 3.11 3.12 3.13
+RUN pyenv local 3.8 3.9 3.10 3.11 3.12 3.13
 RUN pyenv global ${VARIANT}
 
 # Set up pyenv-virtualenv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": {
-			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+			// Update 'VARIANT' to pick a Python version: 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "3.10",

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -23,7 +23,7 @@ Running Tox locally
 #######################################
 1. Install Python versions for each supported version.
 2. Deactivate your local virtualenv (if it's activated).
-3. Run ``pyenv local 3.13.X 3.12.X 3.111.X 3.10.X 3.9.Y 3.8.Z`` (inserting appropriate patch versions).
+3. Run ``pyenv local 3.13.X 3.12.X 3.11.X 3.10.X 3.9.Y 3.8.Z`` (inserting appropriate patch versions).
 4. Run ``make install`` to get latest local dependencies.
 5. Run ``make tox`` to run tox.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -23,7 +23,7 @@ Running Tox locally
 #######################################
 1. Install Python versions for each supported version.
 2. Deactivate your local virtualenv (if it's activated).
-3. Run ``pyenv local 3.10.X 3.9.Y 3.8.Z 3.7.12`` (inserting appropriate patch versions).
+3. Run ``pyenv local 3.13.X 3.12.X 3.111.X 3.10.X 3.9.Y 3.8.Z`` (inserting appropriate patch versions).
 4. Run ``make install`` to get latest local dependencies.
 5. Run ``make tox`` to run tox.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,18 +9,18 @@ authors = [
 description = "Python client for the Unleash feature toggle system!"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312,py313
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Drops support for the now EOL Python3.7 (which is causing some issues with build tooling on the Yggdrasil side). Formally support Python 3.13. Cleans up some references around Python3.6 (long gone) and Python 3.12 (should have been in, were missing)