### PR TITLE
Fix/custom context properties are moved to properties

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -447,7 +447,7 @@ class UnleashClient:
         if "currentTime" not in new_context:
             new_context["currentTime"] = datetime.now(timezone.utc).isoformat()
 
-        safe_properties = self._extract_properties(context or {})
+        safe_properties = self._extract_properties(new_context)
         safe_properties = {
             k: self._safe_context_value(v) for k, v in safe_properties.items()
         }

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -17,6 +17,7 @@ from tests.utilities.mocks.mock_features import (
     MOCK_FEATURE_WITH_DATE_AFTER_CONSTRAINT,
     MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE,
     MOCK_FEATURE_WITH_NUMERIC_CONSTRAINT,
+    MOCK_FEATURE_WITH_CUSTOM_CONTEXT_REQUIREMENTS,
 )
 from tests.utilities.testing_constants import (
     APP_NAME,
@@ -989,3 +990,44 @@ def test_context_moves_properties_fields_to_properties():
     context = {"myContext": "1234"}
 
     assert "myContext" in unleash_client._safe_context(context)["properties"]
+
+
+def test_existing_properties_are_retained_when_custom_context_properties_are_in_the_root():
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        disable_metrics=True,
+        disable_registration=True,
+    )
+
+    context = {"myContext": "1234", "properties": {"yourContext": "1234"}}
+
+    assert "myContext" in unleash_client._safe_context(context)["properties"]
+    assert "yourContext" in unleash_client._safe_context(context)["properties"]
+
+def test_base_context_properties_are_retained_in_root():
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        disable_metrics=True,
+        disable_registration=True,
+    )
+
+    context = {"userId": "1234"}
+
+    assert "userId" in unleash_client._safe_context(context)
+
+
+def test_is_enabled_works_with_properties_field_in_the_context_root():
+    cache = FileCache("MOCK_CACHE")
+    cache.bootstrap_from_dict(MOCK_FEATURE_WITH_CUSTOM_CONTEXT_REQUIREMENTS)
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        disable_metrics=True,
+        cache=cache,
+        disable_registration=True,
+    )
+
+    context = {"myContext": "1234"}
+    assert unleash_client.is_enabled("customContextToggle", context)

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -976,3 +976,16 @@ def test_context_adds_current_time_if_not_set():
     )
 
     assert unleash_client.is_enabled("DateConstraint")
+
+
+def test_context_moves_properties_fields_to_properties():
+    unleash_client = UnleashClient(
+        URL,
+        APP_NAME,
+        disable_metrics=True,
+        disable_registration=True,
+    )
+
+    context = {"myContext": "1234"}
+
+    assert "myContext" in unleash_client._safe_context(context)["properties"]

--- a/tests/utilities/mocks/mock_features.py
+++ b/tests/utilities/mocks/mock_features.py
@@ -352,3 +352,30 @@ MOCK_FEATURE_WITH_DATE_AFTER_CONSTRAINT = {
         },
     ],
 }
+
+MOCK_FEATURE_WITH_CUSTOM_CONTEXT_REQUIREMENTS = {
+    "version": 1,
+    "features": [
+        {
+            "name": "customContextToggle",
+            "description": "Feature toggle with custom context constraint",
+            "enabled": True,
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {},
+                    "constraints": [
+                        {
+                            "contextName": "myContext",
+                            "operator": "IN",
+                            "values": ["1234"],
+                            "inverted": False,
+                        }
+                    ],
+                }
+            ],
+            "createdAt": "2018-10-09T06:04:05.667Z",
+            "impressionData": False,
+        },
+    ],
+}


### PR DESCRIPTION
This forces custom context properties in the `properties` field on the context before sending it to Yggdrasil. Previously the Python SDK would treat all context properties the same, which is a pretty big deviation from other SDKs. This re-enables this behavior in a way that Yggdrasil can handle