### PR TITLE
feat: new headers and payload ( connection id and interval)

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -110,7 +110,7 @@ class UnleashClient:
         self.unleash_app_name = app_name
         self.unleash_environment = environment
         self.unleash_instance_id = instance_id
-        self.connection_id = str(uuid.uuid4())
+        self._connection_id = str(uuid.uuid4())
         self.unleash_refresh_interval = refresh_interval
         self.unleash_request_timeout = request_timeout
         self.unleash_request_retries = request_retries
@@ -187,6 +187,10 @@ class UnleashClient:
     @property
     def unleash_refresh_interval_str_millis(self) -> str:
         return str(self.unleash_refresh_interval * 1000)
+
+    @property
+    def connection_id(self):
+        return self._connection_id
 
     def initialize_client(self, fetch_toggles: bool = True) -> None:
         """

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -5,7 +5,6 @@ import uuid
 import warnings
 from dataclasses import asdict
 from datetime import datetime, timezone
-from sys import base_prefix
 from typing import Any, Callable, Dict, Optional
 
 from apscheduler.executors.pool import ThreadPoolExecutor

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -110,6 +110,7 @@ class UnleashClient:
         self.unleash_app_name = app_name
         self.unleash_environment = environment
         self.unleash_instance_id = instance_id
+        self.connection_id = str(uuid.uuid4())
         self.unleash_refresh_interval = refresh_interval
         self.unleash_request_timeout = request_timeout
         self.unleash_request_retries = request_retries
@@ -215,7 +216,8 @@ class UnleashClient:
             try:
                 headers = {
                     **self.unleash_custom_headers,
-                    "unleash-connection-id": str(uuid.uuid4()),
+                    "unleash-connection-id": self.connection_id,
+                    "unleash-interval-id": self.unleash_refresh_interval,
                     "unleash-appname": self.unleash_app_name,
                     "unleash-sdk": f"{SDK_NAME}:{SDK_VERSION}",
                 }
@@ -224,6 +226,7 @@ class UnleashClient:
                 metrics_args = {
                     "url": self.unleash_url,
                     "app_name": self.unleash_app_name,
+                    "connection_id": self.connection_id,
                     "instance_id": self.unleash_instance_id,
                     "headers": headers,
                     "custom_options": self.unleash_custom_options,

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -231,7 +231,6 @@ class UnleashClient:
                     "url": self.unleash_url,
                     "app_name": self.unleash_app_name,
                     "connection_id": self.connection_id,
-                    "interval": self.unleash_refresh_interval,
                     "instance_id": self.unleash_instance_id,
                     "headers": headers,
                     "custom_options": self.unleash_custom_options,

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -289,7 +289,6 @@ class UnleashClient:
                     executor=self.unleash_executor_name,
                     kwargs=job_args,
                 )
-
                 if not self.unleash_disable_metrics:
                     self.metric_job = self.unleash_scheduler.add_job(
                         aggregate_and_send_metrics,

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -184,6 +184,10 @@ class UnleashClient:
                 engine=self.engine,
             )
 
+    @property
+    def unleash_refresh_interval_str_millis(self) -> str:
+        return str(self.unleash_refresh_interval * 1000)
+
     def initialize_client(self, fetch_toggles: bool = True) -> None:
         """
         Initializes client and starts communication with central unleash server(s).
@@ -217,7 +221,7 @@ class UnleashClient:
                 headers = {
                     **self.unleash_custom_headers,
                     "unleash-connection-id": self.connection_id,
-                    "unleash-interval-id": self.unleash_refresh_interval,
+                    "unleash-interval-id": self.unleash_refresh_interval_str_millis,
                     "unleash-appname": self.unleash_app_name,
                     "unleash-sdk": f"{SDK_NAME}:{SDK_VERSION}",
                 }
@@ -227,6 +231,7 @@ class UnleashClient:
                     "url": self.unleash_url,
                     "app_name": self.unleash_app_name,
                     "connection_id": self.connection_id,
+                    "interval": self.unleash_refresh_interval,
                     "instance_id": self.unleash_instance_id,
                     "headers": headers,
                     "custom_options": self.unleash_custom_options,
@@ -240,6 +245,7 @@ class UnleashClient:
                         self.unleash_url,
                         self.unleash_app_name,
                         self.unleash_instance_id,
+                        self.connection_id,
                         self.unleash_metrics_interval,
                         headers,
                         self.unleash_custom_options,

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -21,6 +21,7 @@ def register_client(
     url: str,
     app_name: str,
     instance_id: str,
+    connection_id: str,
     metrics_interval: int,
     headers: dict,
     custom_options: dict,
@@ -47,6 +48,7 @@ def register_client(
     registration_request = {
         "appName": app_name,
         "instanceId": instance_id,
+        "connectionId": connection_id,
         "sdkVersion": f"{SDK_NAME}:{SDK_VERSION}",
         "strategies": [*supported_strategies],
         "started": datetime.now(timezone.utc).isoformat(),

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -12,6 +12,7 @@ def aggregate_and_send_metrics(
     url: str,
     app_name: str,
     instance_id: str,
+    connection_id: str,
     headers: dict,
     custom_options: dict,
     request_timeout: int,
@@ -22,6 +23,7 @@ def aggregate_and_send_metrics(
     metrics_request = {
         "appName": app_name,
         "instanceId": instance_id,
+        "connectionId": connection_id,
         "bucket": metrics_bucket,
         "platformName": python_implementation(),
         "platformVersion": python_version(),

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -1,3 +1,5 @@
+import json
+
 import responses
 from pytest import mark, param
 from requests import ConnectionError
@@ -36,5 +38,9 @@ def test_send_metrics(payload, status, expected):
         URL, MOCK_METRICS_REQUEST, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT
     )
 
+    request = json.loads(responses.calls[0].request.body)
+
     assert len(responses.calls) == 1
     assert expected(result)
+
+    assert request["connectionId"] == MOCK_METRICS_REQUEST.get('connectionId')

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -11,7 +11,7 @@ from tests.utilities.testing_constants import (
     INSTANCE_ID,
     METRICS_INTERVAL,
     REQUEST_TIMEOUT,
-    URL,
+    URL, CONNECTION_ID,
 )
 from UnleashClient.api import register_client
 from UnleashClient.constants import CLIENT_SPEC_VERSION, REGISTER_URL
@@ -40,6 +40,7 @@ def test_register_client(payload, status, expected):
         URL,
         APP_NAME,
         INSTANCE_ID,
+        CONNECTION_ID,
         METRICS_INTERVAL,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
@@ -59,6 +60,7 @@ def test_register_includes_metadata():
         URL,
         APP_NAME,
         INSTANCE_ID,
+        CONNECTION_ID,
         METRICS_INTERVAL,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
@@ -71,5 +73,6 @@ def test_register_includes_metadata():
 
     assert request["yggdrasilVersion"] is not None
     assert request["specVersion"] == CLIENT_SPEC_VERSION
+    assert request["connectionId"] == CONNECTION_ID
     assert request["platformName"] is not None
     assert request["platformVersion"] is not None

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -5,11 +5,12 @@ from yggdrasil_engine.engine import UnleashEngine
 
 from tests.utilities.testing_constants import (
     APP_NAME,
+    CONNECTION_ID,
     CUSTOM_HEADERS,
     CUSTOM_OPTIONS,
     INSTANCE_ID,
     REQUEST_TIMEOUT,
-    URL, CONNECTION_ID,
+    URL,
 )
 from UnleashClient.constants import (
     CLIENT_SPEC_VERSION,

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -9,7 +9,7 @@ from tests.utilities.testing_constants import (
     CUSTOM_OPTIONS,
     INSTANCE_ID,
     REQUEST_TIMEOUT,
-    URL,
+    URL, CONNECTION_ID,
 )
 from UnleashClient.constants import (
     CLIENT_SPEC_VERSION,
@@ -31,6 +31,7 @@ def test_no_metrics():
         URL,
         APP_NAME,
         INSTANCE_ID,
+        CONNECTION_ID,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
         REQUEST_TIMEOUT,
@@ -51,6 +52,7 @@ def test_metrics_metadata_is_sent():
         URL,
         APP_NAME,
         INSTANCE_ID,
+        CONNECTION_ID,
         CUSTOM_HEADERS,
         CUSTOM_OPTIONS,
         REQUEST_TIMEOUT,

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1089,12 +1089,14 @@ def test_identification_values_are_passed_in():
     )
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
-    input_interval = 1
+    refresh_interval = 1
+    metrics_interval = 2
     unleash_client = UnleashClient(
-        URL, APP_NAME, refresh_interval=input_interval, metrics_interval=1
+        URL, APP_NAME, refresh_interval=refresh_interval, metrics_interval=metrics_interval
     )
     expected_connection_id = unleash_client.connection_id
-    expected_interval = str(input_interval * 1000)
+    expected_refresh_interval = str(refresh_interval * 1000)
+    expected_metrics_interval = str(metrics_interval * 1000)
 
     unleash_client.initialize_client()
     register_request = responses.calls[0].request
@@ -1108,14 +1110,14 @@ def test_identification_values_are_passed_in():
     features_request = responses.calls[1].request
 
     assert features_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
-    assert features_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
+    assert features_request.headers["UNLEASH-INTERVAL"] == expected_refresh_interval
 
-    time.sleep(2)
+    time.sleep(3)
     metrics_request = [call for call in responses.calls if METRICS_URL in call.request.url][0].request
     metrics_body = json.loads(metrics_request.body)
 
 
     assert metrics_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
-    assert metrics_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
+    assert metrics_request.headers["UNLEASH-INTERVAL"] == expected_metrics_interval
     assert metrics_body['connectionId'] == expected_connection_id
 

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1098,10 +1098,12 @@ def test_identification_values_are_passed_in():
 
     unleash_client.initialize_client()
     register_request = responses.calls[0].request
-    reqister_body = json.loads(register_request.body)
+    register_body = json.loads(register_request.body)
 
     assert register_request.headers[ "UNLEASH-CONNECTION-ID"] == expected_connection_id
-    assert reqister_body['connectionId'] == expected_connection_id
+    assert register_body['connectionId'] == expected_connection_id
+
+    unleash_client.is_enabled("registerMetricsFlag")
 
     features_request = responses.calls[1].request
 
@@ -1109,8 +1111,11 @@ def test_identification_values_are_passed_in():
     assert features_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
 
     time.sleep(2)
-    metrics_request = responses.calls[2].request
+    metrics_request = [call for call in responses.calls if METRICS_URL in call.request.url][0].request
+    metrics_body = json.loads(metrics_request.body)
+
 
     assert metrics_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
     assert metrics_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
+    assert metrics_body['connectionId'] == expected_connection_id
 

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1044,11 +1044,13 @@ def test_identification_headers_sent_and_consistent(unleash_client):
     unleash_client.initialize_client()
 
     connection_id = responses.calls[0].request.headers["UNLEASH-CONNECTION-ID"]
+    # interval = responses.calls[0].request.headers["UNLEASH-INTERVAL"]
     app_name = responses.calls[0].request.headers["UNLEASH-APPNAME"]
     sdk = responses.calls[0].request.headers["UNLEASH-SDK"]
 
     for api_call in responses.calls:
         assert api_call.request.headers["UNLEASH-CONNECTION-ID"] == connection_id
+        # assert api_call.request.headers["UNLEASH-INTERVAL"] == interval
         assert api_call.request.headers["UNLEASH-APPNAME"] == app_name
         assert api_call.request.headers["UNLEASH-SDK"] == sdk
 

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1082,30 +1082,35 @@ def test_identification_headers_unique_connection_id():
 
 
 @responses.activate
-def test_identification_values_are_passed_in(unleash_client):
+def test_identification_values_are_passed_in():
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
     responses.add(
         responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
     )
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
+    input_interval = 1
+    unleash_client = UnleashClient(
+        URL, APP_NAME, refresh_interval=input_interval, metrics_interval=1
+    )
     expected_connection_id = unleash_client.connection_id
-    expected_interval = str(REFRESH_INTERVAL * 1000)
+    expected_interval = str(input_interval * 1000)
 
     unleash_client.initialize_client()
     register_request = responses.calls[0].request
     reqister_body = json.loads(register_request.body)
 
-    assert register_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
-    assert reqister_body["connectionId"] == expected_connection_id
+    assert register_request.headers[ "UNLEASH-CONNECTION-ID"] == expected_connection_id
+    assert reqister_body['connectionId'] == expected_connection_id
 
     features_request = responses.calls[1].request
 
     assert features_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
     assert features_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
 
-    time.sleep(METRICS_INTERVAL + 2)
+    time.sleep(2)
     metrics_request = responses.calls[2].request
 
     assert metrics_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
     assert metrics_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
+

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1099,8 +1099,6 @@ def test_identification_values_are_passed_in():
         metrics_interval=metrics_interval,
     )
 
-
-    expected_connection_id = unleash_client.connection_id
     expected_refresh_interval = str(refresh_interval * 1000)
     expected_metrics_interval = str(metrics_interval * 1000)
 

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1082,19 +1082,15 @@ def test_identification_headers_unique_connection_id():
 
 
 @responses.activate
-def test_identification_values_are_passed_in():
+def test_identification_values_are_passed_in(unleash_client):
     responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
     responses.add(
         responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
     )
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
 
-    input_interval = 1
-    unleash_client = UnleashClient(
-        URL, APP_NAME, refresh_interval=input_interval, metrics_interval=1
-    )
     expected_connection_id = unleash_client.connection_id
-    expected_interval = str(input_interval * 1000)
+    expected_interval = str(REFRESH_INTERVAL * 1000)
 
     unleash_client.initialize_client()
     register_request = responses.calls[0].request
@@ -1108,7 +1104,7 @@ def test_identification_values_are_passed_in():
     assert features_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id
     assert features_request.headers["UNLEASH-INTERVAL-ID"] == expected_interval
 
-    time.sleep(2)
+    time.sleep(METRICS_INTERVAL + 2)
     metrics_request = responses.calls[2].request
 
     assert metrics_request.headers["UNLEASH-CONNECTION-ID"] == expected_connection_id

--- a/tests/utilities/mocks/mock_metrics.py
+++ b/tests/utilities/mocks/mock_metrics.py
@@ -1,6 +1,7 @@
 MOCK_METRICS_REQUEST = {
     "appName": "appName",
     "instanceId": "instanceId",
+    "connectionId": "connectionId",
     "bucket": {
         "start": "2016-11-03T07:16:43.572Z",
         "stop": "2016-11-03T07:16:53.572Z",

--- a/tests/utilities/testing_constants.py
+++ b/tests/utilities/testing_constants.py
@@ -4,6 +4,7 @@ from UnleashClient.constants import FEATURES_URL
 APP_NAME = "pytest"
 ENVIRONMENT = "unit"
 INSTANCE_ID = "123"
+CONNECTION_ID = "test-connection-id"
 REFRESH_INTERVAL = 3
 REFRESH_JITTER = None
 METRICS_INTERVAL = 2


### PR DESCRIPTION
## Request updates

- Fetch flag calls include the `unleash-interval` header.
- Registration calls now have `connectionId` added to the payload (previously, it only had the `unleash-connection-id` header).

## Metrics updates

- Send metrics calls include the `unleash-interval` header.
- Send metrics now have `connectionId` added to the payload (previously, it only had the `unleash-connection-id` header).
