### PR TITLE
fix: feature toggle keys iteration

### DIFF
--- a/UnleashClient/loader.py
+++ b/UnleashClient/loader.py
@@ -132,7 +132,7 @@ def load_features(
             del feature_toggles[feature]
 
     # Update existing objects
-    for feature in feature_toggles.keys():
+    for feature in list(feature_toggles.keys()):
         feature_for_update = feature_toggles[feature]
         strategies = parsed_features[feature]["strategies"]
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3542/feature-toggles-not-updating-for-yousician-incident

This patch fixes a bug in the feature loader where a `RuntimeError: dictionary changed size during iteration` could occur if `feature_toggles` was mutated while iterating over its keys.

The fix wraps the iteration in `list(...)` to safely snapshot the keys before the loop begins, preventing any potential crash.

This PR is based on a new v5 branch created from the [v5.12.3 tag](https://github.com/Unleash/unleash-client-python/tree/v5.12.3) to support patch releases for the 5.x line.