### PR TITLE
Flush metrics on destroy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install-docs: install
 #-----------------------------------------------------------------------
 fmt:
 	black . && \
-	ruff UnleashClient tests --fix
+	ruff check UnleashClient tests --fix
 
 lint:
 	black . --check && \

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -72,7 +72,8 @@ def get_feature_toggles(
         if resp.status_code not in [200, 304]:
             log_resp_info(resp)
             LOGGER.warning(
-                "Unleash Client feature fetch failed due to unexpected HTTP status code: %s", resp.status_code
+                "Unleash Client feature fetch failed due to unexpected HTTP status code: %s",
+                resp.status_code,
             )
             raise Exception(
                 "Unleash Client feature fetch failed!"

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -72,7 +72,7 @@ def get_feature_toggles(
         if resp.status_code not in [200, 304]:
             log_resp_info(resp)
             LOGGER.warning(
-                "Unleash Client feature fetch failed due to unexpected HTTP status code."
+                "Unleash Client feature fetch failed due to unexpected HTTP status code: %s", resp.status_code
             )
             raise Exception(
                 "Unleash Client feature fetch failed!"

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -41,7 +41,10 @@ def send_metrics(
 
         if resp.status_code != 202:
             log_resp_info(resp)
-            LOGGER.warning("Unleash Client metrics submission failed.")
+            LOGGER.warning(
+                "Unleash Client metrics submission due to unexpected HTTP status code: %s",
+                resp.status_code,
+            )
             return False
 
         LOGGER.info("Unleash Client metrics successfully sent!")

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -74,7 +74,8 @@ def register_client(
         if resp.status_code != 202:
             log_resp_info(resp)
             LOGGER.warning(
-                "Unleash Client registration failed due to unexpected HTTP status code: %s", resp.status_code
+                "Unleash Client registration failed due to unexpected HTTP status code: %s",
+                resp.status_code,
             )
             return False
 

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -74,7 +74,7 @@ def register_client(
         if resp.status_code != 202:
             log_resp_info(resp)
             LOGGER.warning(
-                "Unleash Client registration failed due to unexpected HTTP status code."
+                "Unleash Client registration failed due to unexpected HTTP status code: %s", resp.status_code
             )
             return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ mypy
 pylint
 pytest
 pytest-cov
-pytest-html==4.0.0rc4
+pytest-html
 pytest-mock
 pytest-xdist
 responses

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -394,6 +394,14 @@ def test_uc_context_manager(unleash_client_nodestroy):
 
     with unleash_client_nodestroy as unleash_client:
         assert unleash_client.is_initialized
+        assert unleash_client.is_enabled("testFlag")
+
+    # Context use case is usualy short-lived so even with a METRICS_INTERVAL of 2 seconds metrics can get lost.  Verify that metrics are sent on destroy.
+    metrics_request = [
+        call for call in responses.calls if METRICS_URL in call.request.url
+    ][0].request
+    metrics_body = json.loads(metrics_request.body)
+    assert metrics_body["bucket"]["toggles"]["testFlag"]["yes"] == 1
 
 
 @responses.activate

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -396,7 +396,7 @@ def test_uc_context_manager(unleash_client_nodestroy):
         assert unleash_client.is_initialized
         assert unleash_client.is_enabled("testFlag")
 
-    # Context use case is usualy short-lived so even with a METRICS_INTERVAL of 2 seconds metrics can get lost.  Verify that metrics are sent on destroy.
+    # Context Manager use case is usualy short-lived so even with a METRICS_INTERVAL of 2 seconds metrics can get lost.  Verify that metrics are sent on destroy.
     metrics_request = [
         call for call in responses.calls if METRICS_URL in call.request.url
     ][0].request


### PR DESCRIPTION
# Description

UnleashClient's `destroy()` function was just unregistering the metrics job and not flushing metrics.  This can lead to up to N seconds where N = metrics job interval of metrics to get lost.  

Changes:
- If metrics are enabled, `destroy()` will try and flush metrics after metrics job is unscheduled (to avoid dupes).
- Light refactoring to share code between initialize/destroy functions.
- Add error code for when API calls fail to make troubleshooting easier.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
