### PR TITLE
Feat/streaming disconnect logging

### DIFF
--- a/UnleashClient/connectors/streaming_connector.py
+++ b/UnleashClient/connectors/streaming_connector.py
@@ -112,9 +112,8 @@ class StreamingConnector(BaseConnector):
         if error is None:
             if not self._stop.is_set():
                 LOGGER.info("SSE stream ended - server closed connection gracefully")
-        else:
-            if not self._stop.is_set():
-                LOGGER.warning("SSE stream error: %s - will retry", error)
+        elif not self._stop.is_set():
+            LOGGER.warning("SSE stream error: %s - will retry", error)
 
     def _close_client(self) -> None:
         try:


### PR DESCRIPTION
Refactor streaming connector to add _disconnect_ logging and simplify _run.

I changed iteration to `client.all` from `client.events` to log disconnection warnings. After that `_run` had deep nesting. I pulled setup, event handling, error handling, and cleanup into smaller, flatter methods.

Example log when disconnected from Edge now looks like this:
```log
INFO:UnleashClient:Connecting to stream at http://localhost:3063/api/client/streaming
DEBUG:urllib3.connectionpool:Resetting dropped connection: localhost
WARNING:UnleashClient:SSE stream error: <urllib3.connection.HTTPConnection object at 0x7fb2863b02d0>: Failed to establish a new connection: [Errno 111] Connection refused - will retry
INFO:UnleashClient:Will reconnect after delay of 3.090826s
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
