### PR TITLE
fix: do not delete cache on destroy

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -487,7 +487,6 @@ class UnleashClient:
             except Exception as exc:
                 LOGGER.warning("Exception during scheduler teardown: %s", exc)
 
-
     @staticmethod
     def _get_fallback_value(
         fallback_function: Callable, feature_name: str, context: dict

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -487,10 +487,14 @@ class UnleashClient:
             except Exception as exc:
                 LOGGER.warning("Exception during scheduler teardown: %s", exc)
 
-            try:
-                self.cache.destroy()
-            except Exception as exc:
-                LOGGER.warning("Exception during cache teardown: %s", exc)
+            # The default SDK FileCache is disk-backed and can be shared by
+            # multiple processes for the same app name. Avoid deleting it
+            # during shutdown to prevent cross-process cache races.
+            if not isinstance(self.cache, FileCache):
+                try:
+                    self.cache.destroy()
+                except Exception as exc:
+                    LOGGER.warning("Exception during cache teardown: %s", exc)
 
     @staticmethod
     def _get_fallback_value(

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -487,14 +487,6 @@ class UnleashClient:
             except Exception as exc:
                 LOGGER.warning("Exception during scheduler teardown: %s", exc)
 
-            # The default SDK FileCache is disk-backed and can be shared by
-            # multiple processes for the same app name. Avoid deleting it
-            # during shutdown to prevent cross-process cache races.
-            if not isinstance(self.cache, FileCache):
-                try:
-                    self.cache.destroy()
-                except Exception as exc:
-                    LOGGER.warning("Exception during cache teardown: %s", exc)
 
     @staticmethod
     def _get_fallback_value(

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -487,6 +487,14 @@ class UnleashClient:
             except Exception as exc:
                 LOGGER.warning("Exception during scheduler teardown: %s", exc)
 
+            # Disk-backed FileCache instances can be shared across processes.
+            # Avoid deleting them during shutdown to prevent cache races.
+            if not isinstance(self.cache, FileCache):
+                try:
+                    self.cache.destroy()
+                except Exception as exc:
+                    LOGGER.warning("Exception during cache teardown: %s", exc)
+
     @staticmethod
     def _get_fallback_value(
         fallback_function: Callable, feature_name: str, context: dict

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -451,7 +451,12 @@ class UnleashClient:
 
     def destroy(self) -> None:
         """
-        Gracefully shuts down the Unleash client by stopping jobs, stopping the scheduler, and deleting the cache.
+        Gracefully shuts down the Unleash client by stopping jobs and stopping
+        the scheduler.
+
+        For cache teardown:
+        - Default disk-backed FileCache instances are preserved on disk.
+        - Custom non-FileCache implementations will have destroy() called.
 
         You shouldn't need this too much!
         """

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -43,7 +43,7 @@ from tests.utilities.testing_constants import (
     URL,
 )
 from UnleashClient import INSTANCES, UnleashClient
-from UnleashClient.cache import FileCache
+from UnleashClient.cache import BaseCache, FileCache
 from UnleashClient.constants import FEATURES_URL, METRICS_URL, REGISTER_URL
 from UnleashClient.events import BaseEvent, UnleashEvent, UnleashEventType
 from UnleashClient.utils import InstanceAllowType
@@ -93,7 +93,8 @@ def before_each():
 
 @pytest.fixture
 def cache(tmpdir):
-    return FileCache(APP_NAME, directory=tmpdir.dirname)
+    # Keep cache isolated per test; client.destroy() no longer clears FileCache.
+    return FileCache(APP_NAME, directory=tmpdir.strpath)
 
 
 @pytest.fixture()
@@ -1545,3 +1546,51 @@ def test_shutdown_calls_scheduler_at_most_once():
     unleash_client.destroy()
 
     assert scheduler.shutdown_called == 1
+
+
+def test_destroy_skips_default_file_cache_destroy(monkeypatch):
+    unleash_client = UnleashClient(
+        URL, APP_NAME, disable_metrics=True, disable_registration=True
+    )
+    destroy_calls = 0
+
+    def count_destroy():
+        nonlocal destroy_calls
+        destroy_calls += 1
+
+    monkeypatch.setattr(unleash_client.cache, "destroy", count_destroy)
+
+    unleash_client.destroy()
+
+    assert destroy_calls == 0
+
+
+def test_destroy_calls_custom_cache_destroy():
+    class CustomCache(BaseCache):
+        def __init__(self):
+            self.destroy_calls = 0
+            self.store = {}
+
+        def set(self, key: str, value):
+            self.store[key] = value
+
+        def mset(self, data: dict):
+            self.store.update(data)
+
+        def get(self, key: str, default=None):
+            return self.store.get(key, default)
+
+        def exists(self, key: str):
+            return key in self.store
+
+        def destroy(self):
+            self.destroy_calls += 1
+
+    cache = CustomCache()
+    unleash_client = UnleashClient(
+        URL, APP_NAME, cache=cache, disable_metrics=True, disable_registration=True
+    )
+
+    unleash_client.destroy()
+
+    assert cache.destroy_calls == 1


### PR DESCRIPTION
# Description

Fix `UnleashClient.destroy()` behavior so it no longer deletes the default SDK FileCache on shutdown.

Previously, shutdown always called `cache.destroy()`. For the default FileCache, this could remove shared on-disk cache data and break other live processes using the same app_name cache path (reported in #390). The fix preserves shutdown behavior for connector/scheduler/metrics while skipping cache deletion for default FileCache. Custom cache implementations still receive destroy() as before.

This is a targeted mitigation for the teardown race in #390. It does not fully address broader multiprocessing limitations of fcache discussed in #303.

Fixes #390

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Added/updated unit tests:
- test_destroy_skips_default_file_cache_destroy
- test_destroy_calls_custom_cache_destroy

Also updated cache fixture isolation in unit tests (tmpdir.strpath) to avoid cross-test cache leakage now that default FileCache is not deleted during client shutdown.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules