### PR TITLE
feat: add sdk flavor metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ Unleash is a private, secure, and scalable [feature management platform](https:/
 
 You can use this client with [Unleash Enterprise](https://www.getunleash.io/pricing?utm_source=readme&utm_medium=python) or [Unleash Open Source](https://github.com/Unleash/unleash).
 
->  **Migrating to v6**
+> **Migrating to v6**
 >
 > If you use custom strategies or access the `features` property on the Unleash Client, read the complete [migration guide](./v6_MIGRATION_GUIDE.md) before upgrading to v6.
-
 
 ## Getting Started
 
@@ -112,30 +111,30 @@ The client will evaluate the fallback function if the feature flag is not found 
 
 The UnleashClient constructor supports the following configuration options:
 
-| Parameter 	            | Description	                                                                                                                                    | Default                   |
-| ------------ 	            | ------------                      	                                                                                                            | ------------              |
-| url 	                    | URL of your Unleash server. E.g. `https://app.unleash-hosted.com/demo/api/` Required.                                                             | None                      |
-| app_name 	                | Name of the application using the client. Required.	                                                                                            | None                      |
-| environment               | Logical environment name (deprecated).	                                                                                                        | "default"                 |
-| instance_id               | Unique identifier for this client instance.	                                                                                                    | "unleash-client-python"   |
-| refresh_interval  	    | How often to fetch feature flags (seconds).	                                                                                                    | 15                        |
-| refresh_jitter            | Jitter to add to refresh interval (seconds).	                                                                                                    | None                      |
-| metrics_interval  	    | How often to send metrics to Unleash (seconds).	                                                                                                | 60                        |
-| metrics_jitter            | Jitter to add to metrics interval (seconds).	                                                                                                    | None                      |
-| disable_metrics           | Disable sending usage metrics.	                                                                                                                | False                     |
-| disable_registration      | Disable client registration.	                                                                                                                    | False                     |
-| custom_headers            | Additional HTTP headers (e.g. Authorization).	                                                                                                    | None                      |
+| Parameter              | Description                                                                                                                                     | Default                   |
+| ------------              | ------------                                                                                                                                   | ------------              |
+| url                      | URL of your Unleash server. E.g. `https://app.unleash-hosted.com/demo/api/` Required.                                                             | None                      |
+| app_name                  | Name of the application using the client. Required.                                                                                             | None                      |
+| environment               | Logical environment name (deprecated).                                                                                                         | "default"                 |
+| instance_id               | Unique identifier for this client instance.                                                                                                     | "unleash-client-python"   |
+| refresh_interval       | How often to fetch feature flags (seconds).                                                                                                     | 15                        |
+| refresh_jitter            | Jitter to add to refresh interval (seconds).                                                                                                     | None                      |
+| metrics_interval       | How often to send metrics to Unleash (seconds).                                                                                                 | 60                        |
+| metrics_jitter            | Jitter to add to metrics interval (seconds).                                                                                                     | None                      |
+| disable_metrics           | Disable sending usage metrics.                                                                                                                 | False                     |
+| disable_registration      | Disable client registration.                                                                                                                     | False                     |
+| custom_headers            | Additional HTTP headers (e.g. Authorization).                                                                                                     | None                      |
 | custom_options            | Extra options for [HTTP requests](https://requests.readthedocs.io/en/latest/api/#main-interface).                                                 | None                      |
-| request_timeout           | HTTP request timeout (seconds).	                                                                                                                | 30                        |
-| request_retries           | HTTP request retry count.	                                                                                                                        | 3                         |
-| custom_strategies 	    | Dict of `{name: strategy}` for custom activation strategies. See [custom strategies](#custom-strategies) for more information.                      | None                      |
-| cache_directory 	        | Location for the on-disk cache. Auto-determined.                                                                                                  | None                      |
-| cache 	                | Custom cache implementation (must extend BaseCache). See [custom cache](#custom-cache) for more information                                       | BaseCache                 |
-| scheduler 	            | Custom APScheduler instance.	Auto-created.                                                                                                       | BaseScheduler             |
-| verbose_log_level 	    | Python logging level for debugging feature flag failures. See https://docs.python.org/3/library/logging.html#logging-levels for more information.	| 30                        |
-| scheduler_executor 	    | APScheduler executor name to use.	                                                                                                                | None                      |
-| multiple_instance_mode    | How to handle multiple client instances (BLOCK, WARN, SILENTLY_ALLOW).	                                                                        | WARN                      |
-| event_callback 	        | Function to handle impression events. See [impression data](#impression-data) for more information.                                               | None                      |
+| request_timeout           | HTTP request timeout (seconds).                                                                                                                 | 30                        |
+| request_retries           | HTTP request retry count.                                                                                                                         | 3                         |
+| custom_strategies      | Dict of `{name: strategy}` for custom activation strategies. See [custom strategies](#custom-strategies) for more information.                      | None                      |
+| cache_directory          | Location for the on-disk cache. Auto-determined.                                                                                                  | None                      |
+| cache                  | Custom cache implementation (must extend BaseCache). See [custom cache](#custom-cache) for more information                                       | BaseCache                 |
+| scheduler              | Custom APScheduler instance. Auto-created.                                                                                                       | BaseScheduler             |
+| verbose_log_level      | Python logging level for debugging feature flag failures. See <https://docs.python.org/3/library/logging.html#logging-levels> for more information. | 30                        |
+| scheduler_executor      | APScheduler executor name to use.                                                                                                                 | None                      |
+| multiple_instance_mode    | How to handle multiple client instances (BLOCK, WARN, SILENTLY_ALLOW).                                                                         | WARN                      |
+| event_callback          | Function to handle impression events. See [impression data](#impression-data) for more information.                                               | None                      |
 
 ### Bootstrap
 
@@ -252,6 +251,7 @@ The Python SDK lets you tap into its behavior through [impression data](https://
 #### Impression events
 
 To use impression data:
+
 - Enable impression data on your feature flags in the Unleash UI.
 - Provide an event_callback function when you initialize the client.
 
@@ -287,6 +287,7 @@ Impression callbacks run in-process — keep them fast to avoid blocking your ap
 #### Lifecycle events
 
 The same event_callback also delivers lifecycle events:
+
 - FETCHED: triggered when a new version of feature flags is pulled from the Unleash server. (Does not trigger on 304 Not Modified). The FETCHED event includes a features property containing all the feature flags returned by that fetch.
 - READY: triggered once when the SDK first loads feature flags from the Unleash server or a local backup.
 
@@ -402,6 +403,7 @@ class CustomCache(BaseCache):
     def destroy(self):
         return self._cache.delete()
 ```
+
 Pass your cache instance to the client with the cache argument:
 
 ```python

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -136,6 +136,8 @@ class UnleashClient:
     :param multiple_instance_mode: Determines how multiple instances being instantiated is handled by the SDK, when set to InstanceAllowType.BLOCK, the client constructor will fail when more than one instance is detected, when set to InstanceAllowType.WARN, multiple instances will be allowed but log a warning, when set to InstanceAllowType.SILENTLY_ALLOW, no warning or failure will be raised when instantiating multiple instances of the client. Defaults to InstanceAllowType.WARN
     :param event_callback: Function to call if impression events are enabled.  WARNING: Depending on your event library, this may have performance implications!
     :param experimental_mode: Optional dict to configure mode. Use {"type": "streaming"} to enable streaming or {"type": "polling"} (default).
+    :param sdk_flavor: Optional identifier of an integration built on top of this SDK (e.g. an OpenFeature provider). Sent in the register + metrics payloads alongside sdkVersion so adoption of the integration can be tracked. Leave unset for plain SDK usage.
+    :param sdk_flavor_version: Optional version of the integration named by sdk_flavor.
     """
 
     def __init__(
@@ -164,6 +166,8 @@ class UnleashClient:
         multiple_instance_mode: InstanceAllowType = InstanceAllowType.WARN,
         event_callback: Optional[Callable[[BaseEvent], None]] = None,
         experimental_mode: Optional[ExperimentalMode] = None,
+        sdk_flavor: Optional[str] = None,
+        sdk_flavor_version: Optional[str] = None,
     ) -> None:
         custom_headers = custom_headers or {}
         custom_options = custom_options or {}
@@ -187,6 +191,8 @@ class UnleashClient:
         )
         self.unleash_disable_metrics = disable_metrics
         self.unleash_disable_registration = disable_registration
+        self.unleash_sdk_flavor = sdk_flavor
+        self.unleash_sdk_flavor_version = sdk_flavor_version
         self.unleash_custom_headers = custom_headers
         self.unleash_custom_options = custom_options
         self.unleash_static_context = {
@@ -340,6 +346,8 @@ class UnleashClient:
                         self.unleash_custom_options,
                         self.strategy_mapping,
                         self.unleash_request_timeout,
+                        self.unleash_sdk_flavor,
+                        self.unleash_sdk_flavor_version,
                     )
                 mode = self.connector_mode.get("type", "polling")
 
@@ -404,6 +412,8 @@ class UnleashClient:
                         "custom_options": self.unleash_custom_options,
                         "request_timeout": self.unleash_request_timeout,
                         "engine": self.engine,
+                        "sdk_flavor": self.unleash_sdk_flavor,
+                        "sdk_flavor_version": self.unleash_sdk_flavor_version,
                     }
 
                     self.metric_job = self.unleash_scheduler.add_job(

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -140,7 +140,7 @@ class UnleashClient:
     :param sdk_flavor_version: Optional version of the integration named by sdk_flavor.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 - configuration-heavy public constructor
         self,
         url: str,
         app_name: str,

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -13,7 +13,7 @@ from UnleashClient.constants import (
     SDK_NAME,
     SDK_VERSION,
 )
-from UnleashClient.utils import LOGGER, log_resp_info
+from UnleashClient.utils import LOGGER, log_resp_info, sdk_flavor_fields
 
 
 # pylint: disable=broad-except
@@ -27,6 +27,8 @@ def register_client(
     custom_options: dict,
     supported_strategies: dict,
     request_timeout: int,
+    sdk_flavor: str = None,
+    sdk_flavor_version: str = None,
 ) -> bool:
     """
     Attempts to register client with unleash server.
@@ -57,6 +59,7 @@ def register_client(
         "platformVersion": python_version(),
         "yggdrasilVersion": yggdrasil_engine.__yggdrasil_core_version__,
         "specVersion": CLIENT_SPEC_VERSION,
+        **sdk_flavor_fields(sdk_flavor, sdk_flavor_version),
     }
 
     try:

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 from platform import python_implementation, python_version
+from typing import Optional
 
 import requests
 import yggdrasil_engine
@@ -13,7 +14,7 @@ from UnleashClient.constants import (
     SDK_NAME,
     SDK_VERSION,
 )
-from UnleashClient.utils import LOGGER, log_resp_info, sdk_flavor_fields
+from UnleashClient.utils import LOGGER, log_resp_info
 
 
 # pylint: disable=broad-except
@@ -27,8 +28,8 @@ def register_client(
     custom_options: dict,
     supported_strategies: dict,
     request_timeout: int,
-    sdk_flavor: str = None,
-    sdk_flavor_version: str = None,
+    sdk_flavor: Optional[str] = None,
+    sdk_flavor_version: Optional[str] = None,
 ) -> bool:
     """
     Attempts to register client with unleash server.
@@ -59,8 +60,12 @@ def register_client(
         "platformVersion": python_version(),
         "yggdrasilVersion": yggdrasil_engine.__yggdrasil_core_version__,
         "specVersion": CLIENT_SPEC_VERSION,
-        **sdk_flavor_fields(sdk_flavor, sdk_flavor_version),
     }
+    # Only sent when the client was configured with an integration flavor
+    if sdk_flavor:
+        registration_request["sdkFlavor"] = sdk_flavor
+    if sdk_flavor_version:
+        registration_request["sdkFlavorVersion"] = sdk_flavor_version
 
     try:
         LOGGER.info("Registering unleash client with unleash @ %s", url)

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -1,11 +1,12 @@
 from platform import python_implementation, python_version
+from typing import Optional
 
 import yggdrasil_engine
 from yggdrasil_engine.engine import UnleashEngine
 
 from UnleashClient.api import send_metrics
 from UnleashClient.constants import CLIENT_SPEC_VERSION
-from UnleashClient.utils import LOGGER, sdk_flavor_fields
+from UnleashClient.utils import LOGGER
 
 
 def aggregate_and_send_metrics(
@@ -17,8 +18,8 @@ def aggregate_and_send_metrics(
     custom_options: dict,
     request_timeout: int,
     engine: UnleashEngine,
-    sdk_flavor: str = None,
-    sdk_flavor_version: str = None,
+    sdk_flavor: Optional[str] = None,
+    sdk_flavor_version: Optional[str] = None,
 ) -> None:
     metrics_bucket = engine.get_metrics()
 
@@ -37,8 +38,12 @@ def aggregate_and_send_metrics(
         "platformVersion": python_version(),
         "yggdrasilVersion": yggdrasil_engine.__yggdrasil_core_version__,
         "specVersion": CLIENT_SPEC_VERSION,
-        **sdk_flavor_fields(sdk_flavor, sdk_flavor_version),
     }
+    # Only sent when the client was configured with an integration flavor
+    if sdk_flavor:
+        metrics_request["sdkFlavor"] = sdk_flavor
+    if sdk_flavor_version:
+        metrics_request["sdkFlavorVersion"] = sdk_flavor_version
 
     if impact_metrics:
         metrics_request["impactMetrics"] = impact_metrics

--- a/UnleashClient/periodic_tasks/send_metrics.py
+++ b/UnleashClient/periodic_tasks/send_metrics.py
@@ -5,7 +5,7 @@ from yggdrasil_engine.engine import UnleashEngine
 
 from UnleashClient.api import send_metrics
 from UnleashClient.constants import CLIENT_SPEC_VERSION
-from UnleashClient.utils import LOGGER
+from UnleashClient.utils import LOGGER, sdk_flavor_fields
 
 
 def aggregate_and_send_metrics(
@@ -17,6 +17,8 @@ def aggregate_and_send_metrics(
     custom_options: dict,
     request_timeout: int,
     engine: UnleashEngine,
+    sdk_flavor: str = None,
+    sdk_flavor_version: str = None,
 ) -> None:
     metrics_bucket = engine.get_metrics()
 
@@ -35,6 +37,7 @@ def aggregate_and_send_metrics(
         "platformVersion": python_version(),
         "yggdrasilVersion": yggdrasil_engine.__yggdrasil_core_version__,
         "specVersion": CLIENT_SPEC_VERSION,
+        **sdk_flavor_fields(sdk_flavor, sdk_flavor_version),
     }
 
     if impact_metrics:

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -9,6 +9,17 @@ from requests import Response
 LOGGER = logging.getLogger("UnleashClient")
 
 
+def sdk_flavor_fields(
+    sdk_flavor: Any = None, sdk_flavor_version: Any = None
+) -> dict:
+    fields = {}
+    if sdk_flavor:
+        fields["sdkFlavor"] = sdk_flavor
+    if sdk_flavor_version:
+        fields["sdkFlavorVersion"] = sdk_flavor_version
+    return fields
+
+
 class InstanceAllowType(Enum):
     BLOCK = 1
     WARN = 2

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -9,15 +9,6 @@ from requests import Response
 LOGGER = logging.getLogger("UnleashClient")
 
 
-def sdk_flavor_fields(sdk_flavor: Any = None, sdk_flavor_version: Any = None) -> dict:
-    fields = {}
-    if sdk_flavor:
-        fields["sdkFlavor"] = sdk_flavor
-    if sdk_flavor_version:
-        fields["sdkFlavorVersion"] = sdk_flavor_version
-    return fields
-
-
 class InstanceAllowType(Enum):
     BLOCK = 1
     WARN = 2

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -9,9 +9,7 @@ from requests import Response
 LOGGER = logging.getLogger("UnleashClient")
 
 
-def sdk_flavor_fields(
-    sdk_flavor: Any = None, sdk_flavor_version: Any = None
-) -> dict:
+def sdk_flavor_fields(sdk_flavor: Any = None, sdk_flavor_version: Any = None) -> dict:
     fields = {}
     if sdk_flavor:
         fields["sdkFlavor"] = sdk_flavor

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -77,3 +77,49 @@ def test_register_includes_metadata():
     assert request["connectionId"] == CONNECTION_ID
     assert request["platformName"] is not None
     assert request["platformVersion"] is not None
+
+
+@responses.activate
+def test_register_includes_sdk_flavor_when_set():
+    responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=202)
+
+    register_client(
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CONNECTION_ID,
+        METRICS_INTERVAL,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        {},
+        REQUEST_TIMEOUT,
+        sdk_flavor="unleash-openfeature-python-provider",
+        sdk_flavor_version="1.2.3",
+    )
+
+    request = json.loads(responses.calls[0].request.body)
+    assert request["sdkFlavor"] == "unleash-openfeature-python-provider"
+    assert request["sdkFlavorVersion"] == "1.2.3"
+    # additive: the SDK version is still present
+    assert request["sdkVersion"] is not None
+
+
+@responses.activate
+def test_register_omits_sdk_flavor_when_unset():
+    responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=202)
+
+    register_client(
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CONNECTION_ID,
+        METRICS_INTERVAL,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        {},
+        REQUEST_TIMEOUT,
+    )
+
+    request = json.loads(responses.calls[0].request.body)
+    assert "sdkFlavor" not in request
+    assert "sdkFlavorVersion" not in request

--- a/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
+++ b/tests/unit_tests/periodic/test_aggregate_and_send_metrics.py
@@ -67,3 +67,51 @@ def test_metrics_metadata_is_sent():
     assert request["specVersion"] == CLIENT_SPEC_VERSION
     assert request["platformName"] is not None
     assert request["platformVersion"] is not None
+
+
+@responses.activate
+def test_metrics_includes_sdk_flavor_when_set():
+    responses.add(responses.POST, FULL_METRICS_URL, json={}, status=200)
+
+    engine = UnleashEngine()
+    engine.count_toggle("something-to-make-sure-metrics-get-sent", True)
+
+    aggregate_and_send_metrics(
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CONNECTION_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        engine,
+        sdk_flavor="unleash-openfeature-python-provider",
+        sdk_flavor_version="1.2.3",
+    )
+
+    request = json.loads(responses.calls[0].request.body)
+    assert request["sdkFlavor"] == "unleash-openfeature-python-provider"
+    assert request["sdkFlavorVersion"] == "1.2.3"
+
+
+@responses.activate
+def test_metrics_omits_sdk_flavor_when_unset():
+    responses.add(responses.POST, FULL_METRICS_URL, json={}, status=200)
+
+    engine = UnleashEngine()
+    engine.count_toggle("something-to-make-sure-metrics-get-sent", True)
+
+    aggregate_and_send_metrics(
+        URL,
+        APP_NAME,
+        INSTANCE_ID,
+        CONNECTION_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        engine,
+    )
+
+    request = json.loads(responses.calls[0].request.body)
+    assert "sdkFlavor" not in request
+    assert "sdkFlavorVersion" not in request


### PR DESCRIPTION
Adds skd flavor metadata when building up and sets them properly when register and send metrics.
Get it ready for use in the provider side