### PR TITLE
chore: fix duplicated coveralls job on CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,8 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-
+    branches:
+      - main
 
 jobs:
   main:


### PR DESCRIPTION
De duplicates the coveralls job on our CI. Before this patch, this was causing coveralls reports to run twice on every PR, coveralls is not a fan and responds by refusing to serve the duplicated job, forcing the check to never get reported to Github, which in turn blocks CI forever