### PR TITLE
fix: normalize metrics, features and registration urls

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -140,7 +140,7 @@ class UnleashClient:
     :param sdk_flavor_version: Optional version of the integration named by sdk_flavor.
     """
 
-    def __init__( # noqa: PLR0913, PLR0917
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         url: str,
         app_name: str,

--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -140,7 +140,7 @@ class UnleashClient:
     :param sdk_flavor_version: Optional version of the integration named by sdk_flavor.
     """
 
-    def __init__(  # noqa: PLR0913 - configuration-heavy public constructor
+    def __init__( # noqa: PLR0913, PLR0917
         self,
         url: str,
         app_name: str,

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -4,6 +4,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
+from UnleashClient.api.urls import get_url
 from UnleashClient.constants import FEATURES_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 
@@ -49,7 +50,7 @@ def get_feature_toggles(
         if cached_etag:
             request_specific_headers["If-None-Match"] = cached_etag
 
-        base_url = f"{url}{FEATURES_URL}"
+        base_url = get_url(url, FEATURES_URL)
         base_params = {}
 
         if project:

--- a/UnleashClient/api/features.py
+++ b/UnleashClient/api/features.py
@@ -4,7 +4,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-from UnleashClient.api.urls import get_url
+from UnleashClient.api.urls import build_normalized_url
 from UnleashClient.constants import FEATURES_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 
@@ -50,7 +50,7 @@ def get_feature_toggles(
         if cached_etag:
             request_specific_headers["If-None-Match"] = cached_etag
 
-        base_url = get_url(url, FEATURES_URL)
+        base_url = build_normalized_url(url, FEATURES_URL)
         base_params = {}
 
         if project:

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from UnleashClient.api.urls import get_url
+from UnleashClient.api.urls import build_normalized_url
 from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 
@@ -33,7 +33,7 @@ def send_metrics(
         LOGGER.info("unleash metrics information: %s", request_body)
 
         resp = requests.post(
-            get_url(url, METRICS_URL),
+            build_normalized_url(url, METRICS_URL),
             data=json.dumps(request_body),
             headers={**headers, **APPLICATION_HEADERS},
             timeout=request_timeout,

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from UnleashClient.api.urls import get_url
 from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL
 from UnleashClient.utils import LOGGER, log_resp_info
 
@@ -32,7 +33,7 @@ def send_metrics(
         LOGGER.info("unleash metrics information: %s", request_body)
 
         resp = requests.post(
-            url + METRICS_URL,
+            get_url(url, METRICS_URL),
             data=json.dumps(request_body),
             headers={**headers, **APPLICATION_HEADERS},
             timeout=request_timeout,

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -7,6 +7,7 @@ import requests
 import yggdrasil_engine
 from requests.exceptions import InvalidHeader, InvalidSchema, InvalidURL, MissingSchema
 
+from UnleashClient.api.urls import get_url
 from UnleashClient.constants import (
     APPLICATION_HEADERS,
     CLIENT_SPEC_VERSION,
@@ -72,7 +73,7 @@ def register_client(
         LOGGER.info("Registration request information: %s", registration_request)
 
         resp = requests.post(
-            url + REGISTER_URL,
+            get_url(url, REGISTER_URL),
             data=json.dumps(registration_request),
             headers={**headers, **APPLICATION_HEADERS},
             timeout=request_timeout,

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -7,7 +7,7 @@ import requests
 import yggdrasil_engine
 from requests.exceptions import InvalidHeader, InvalidSchema, InvalidURL, MissingSchema
 
-from UnleashClient.api.urls import get_url
+from UnleashClient.api.urls import build_normalized_url
 from UnleashClient.constants import (
     APPLICATION_HEADERS,
     CLIENT_SPEC_VERSION,
@@ -73,7 +73,7 @@ def register_client(
         LOGGER.info("Registration request information: %s", registration_request)
 
         resp = requests.post(
-            get_url(url, REGISTER_URL),
+            build_normalized_url(url, REGISTER_URL),
             data=json.dumps(registration_request),
             headers={**headers, **APPLICATION_HEADERS},
             timeout=request_timeout,

--- a/UnleashClient/api/urls.py
+++ b/UnleashClient/api/urls.py
@@ -1,0 +1,2 @@
+def get_url(url: str, path: str) -> str:
+    return f"{url.rstrip('/')}{path}"

--- a/UnleashClient/api/urls.py
+++ b/UnleashClient/api/urls.py
@@ -1,2 +1,2 @@
-def get_url(url: str, path: str) -> str:
+def build_normalized_url(url: str, path: str) -> str:
     return f"{url.rstrip('/')}{path}"

--- a/tests/unit_tests/api/test_feature.py
+++ b/tests/unit_tests/api/test_feature.py
@@ -158,3 +158,29 @@ def test_get_feature_toggle_retries():
     assert len(responses.calls) == 2
     assert len(json.loads(result)["features"]) == 1
     assert etag == ETAG_VALUE
+
+
+@responses.activate
+def test_get_feature_toggle_strips_trailing_slash_from_url():
+    responses.add(
+        responses.GET,
+        FULL_FEATURE_URL,
+        json=MOCK_FEATURE_RESPONSE,
+        status=200,
+        headers={"etag": ETAG_VALUE},
+    )
+
+    (result, etag) = get_feature_toggles(
+        f"{URL}/",
+        APP_NAME,
+        INSTANCE_ID,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+        REQUEST_RETRIES,
+    )
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == FULL_FEATURE_URL
+    assert json.loads(result)["version"] == 1
+    assert etag == ETAG_VALUE

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -44,3 +44,20 @@ def test_send_metrics(payload, status, expected):
     assert expected(result)
 
     assert request["connectionId"] == MOCK_METRICS_REQUEST.get("connectionId")
+
+
+@responses.activate
+def test_send_metrics_strips_trailing_slash_from_url():
+    responses.add(responses.POST, FULL_METRICS_URL, json={}, status=202)
+
+    result = send_metrics(
+        f"{URL}/",
+        MOCK_METRICS_REQUEST,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        REQUEST_TIMEOUT,
+    )
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == FULL_METRICS_URL
+    assert result is True

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -123,3 +123,24 @@ def test_register_omits_sdk_flavor_when_unset():
     request = json.loads(responses.calls[0].request.body)
     assert "sdkFlavor" not in request
     assert "sdkFlavorVersion" not in request
+
+
+@responses.activate
+def test_register_client_strips_trailing_slash_from_url():
+    responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=202)
+
+    result = register_client(
+        f"{URL}/",
+        APP_NAME,
+        INSTANCE_ID,
+        CONNECTION_ID,
+        METRICS_INTERVAL,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        {},
+        REQUEST_TIMEOUT,
+    )
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == FULL_REGISTER_URL
+    assert result is True


### PR DESCRIPTION
Fixes an issue in the URL generation code for metrics, registration and features by preventing double slashes in the URL path when the user sets a Unleash server path with a trailing slash