### PR TITLE
fix: make environment and project visible in log line

### DIFF
--- a/UnleashClient/clients/unleash_client.py
+++ b/UnleashClient/clients/unleash_client.py
@@ -517,7 +517,9 @@ class UnleashClient:
     def _redact_to_print_safely(value: Optional[str]) -> Optional[str]:
         if not value:
             return value
-        return f"{value[:6]}...{value[-3:]}"
+        prefix, separator, secret = value.rpartition(":")
+        redacted_secret = f"{secret[:6]}...{secret[-3:]}"
+        return f"{prefix}{separator}{redacted_secret}"
 
     @staticmethod
     def _get_fallback_value(

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -1049,8 +1049,15 @@ def test_redact_to_print_safely_truncates_middle():
     assert api_key not in redacted
 
 
+def test_redact_to_print_safely_keeps_environment_and_project_visible():
+    api_key = "production:default:abcdef1234567890ghijklmnop"
+    redacted = UnleashClient._redact_to_print_safely(api_key)
+    assert redacted == "production:default:abcdef...nop"
+    assert "abcdef1234567890ghijklmnop" not in redacted
+
+
 def test_api_key_is_not_logged_in_plain_text_in_multiple_instances_warning(caplog):
-    api_key = "abcdef1234567890ghijklmnop"
+    api_key = "production:default:abcdef1234567890ghijklmnop"
     client1 = UnleashClient(
         URL,
         APP_NAME,
@@ -1064,7 +1071,7 @@ def test_api_key_is_not_logged_in_plain_text_in_multiple_instances_warning(caplo
 
     log_text = " ".join(str(r.msg) for r in caplog.records)
     assert api_key not in log_text
-    assert "abcdef...nop" in log_text
+    assert "production:default:abcdef...nop" in log_text
 
     client1.destroy()
     client2.destroy()


### PR DESCRIPTION
These changes come after #400. Failed to include these changes when amending the previous merge request.

The goal of this changes is for the obfuscation to only be applied to the part of the API key that corresponds to _the actual cryptographic key_